### PR TITLE
refactor!: toggle chip size enum

### DIFF
--- a/src/common/enums/NeonToggleChipSize.ts
+++ b/src/common/enums/NeonToggleChipSize.ts
@@ -1,0 +1,13 @@
+/**
+ * The size options for the <a href="/user-input/toggle-chip">NeonToggleChip</a> component.
+ */
+export enum NeonToggleChipSize {
+  /** Extra small, default is 24 rem. */
+  ExtraSmall = 'xs',
+  /** Small, default is 32 rem. */
+  Small = 's',
+  /** Medium, default is 40 rem. */
+  Medium = 'm',
+  /** Large, default is 48 rem. */
+  Large = 'l',
+}

--- a/src/components/user-input/toggle-chip/NeonToggleChip.spec.ts
+++ b/src/components/user-input/toggle-chip/NeonToggleChip.spec.ts
@@ -1,7 +1,7 @@
 import type { RenderResult } from '@testing-library/vue';
 import { fireEvent, render } from '@testing-library/vue';
 import NeonToggleChip from './NeonToggleChip.vue';
-import { NeonSize } from '@/common/enums/NeonSize';
+import { NeonToggleChipSize } from '@/common/enums/NeonToggleChipSize';
 import { NeonFunctionalColor } from '@/common/enums/NeonFunctionalColor';
 
 describe('NeonToggleChip', () => {
@@ -97,7 +97,7 @@ describe('NeonToggleChip', () => {
   it('renders size', async () => {
     const { html, rerender } = harness;
 
-    await rerender({ modelValue: true, size: NeonSize.Small });
+    await rerender({ modelValue: true, size: NeonToggleChipSize.Small });
     const result = html();
     expect(result).toMatch('neon-toggle-chip--s');
   });

--- a/src/components/user-input/toggle-chip/NeonToggleChip.ts
+++ b/src/components/user-input/toggle-chip/NeonToggleChip.ts
@@ -1,5 +1,5 @@
 import { computed, defineComponent, useAttrs } from 'vue';
-import { NeonSize } from '@/common/enums/NeonSize';
+import { NeonToggleChipSize } from '@/common/enums/NeonToggleChipSize';
 import { NeonFunctionalColor } from '@/common/enums/NeonFunctionalColor';
 import NeonIcon from '@/components/presentation/icon/NeonIcon.vue';
 
@@ -27,7 +27,7 @@ export default defineComponent({
     /**
      * The size of the toggle chip.
      */
-    size: { type: String as () => NeonSize, default: NeonSize.Medium },
+    size: { type: String as () => NeonToggleChipSize, default: NeonToggleChipSize.Medium },
     /**
      * The toggle chip color.
      */

--- a/src/neon.ts
+++ b/src/neon.ts
@@ -85,6 +85,7 @@ export { NeonSplashLoaderSize } from './common/enums/NeonSplashLoaderSize';
 export { NeonState } from './common/enums/NeonState';
 export { NeonSwitchStyle } from './common/enums/NeonSwitchStyle';
 export { NeonTabsStyle } from './common/enums/NeonTabsStyle';
+export { NeonToggleChipSize } from './common/enums/NeonToggleChipSize';
 export { NeonToggleStyle } from './common/enums/NeonToggleStyle';
 export { NeonTooltipStyle } from './common/enums/NeonTooltipStyle';
 export { NeonVerticalPosition } from './common/enums/NeonVerticalPosition';


### PR DESCRIPTION
BREAKING: Replace NeonSize enum in NeonToggleChip size property with NeonToggleChipSize enum