### PR TITLE
fix: hide-scrollbars mixin

### DIFF
--- a/src/sass/includes/_scrollbars.scss
+++ b/src/sass/includes/_scrollbars.scss
@@ -21,3 +21,24 @@
     background-color: transparent;
   }
 }
+
+@mixin hide-scrollbars {
+  scrollbar-color: transparent transparent;
+  scrollbar-width: 0;
+
+  &::-webkit-scrollbar {
+    display: none;
+
+    &-thumb {
+      display: none;
+    }
+
+    &-track-piece {
+      display: none;
+    }
+  }
+
+  &::-webkit-scrollbar-corner {
+    display: none;
+  }
+}


### PR DESCRIPTION
Add `hide-scrollbars` mixin for removing scrollbars from scrolling elements. This can be used where there is an alternative scrolling indicator.