### PR TITLE
refactor!: font weight & color variable alignment

### DIFF
--- a/src/app/components/component-documentation/ComponentDocumentation.scss
+++ b/src/app/components/component-documentation/ComponentDocumentation.scss
@@ -106,7 +106,7 @@ $fixed-content-height: 348rem;
 
   &__headline {
     margin-bottom: var(--neon-space-32);
-    font-weight: var(--neon-font-weight-light);
+    font-weight: var(--neon-font-weight-extra-light);
     font-size: var(--neon-h6-size);
     letter-spacing: var(--neon-letter-spacing-m);
     white-space: nowrap;

--- a/src/app/components/component-documentation/ComponentDocumentation.vue
+++ b/src/app/components/component-documentation/ComponentDocumentation.vue
@@ -3,7 +3,7 @@
     <div class="component-documentation__header">
       <div class="component-documentation__header-container">
         <h1 class="component-documentation__title">{{ componentTitle }}</h1>
-        <span v-if="headline" class="component-documentation__headline neon-color-text-neutral">{{ headline }}</span>
+        <span v-if="headline" class="component-documentation__headline neon-color-neutral">{{ headline }}</span>
         <neon-tabs v-model="selected" :tabs="tabs" />
       </div>
     </div>

--- a/src/app/components/editor/Editor.scss
+++ b/src/app/components/editor/Editor.scss
@@ -41,7 +41,7 @@
       &__container {
         display: flex;
         overflow: visible;
-        color: var(--neon-color-text-light);
+        color: var(--neon-color-text-secondary-dark);
       }
 
       &__editor {

--- a/src/app/sass/global.scss
+++ b/src/app/sass/global.scss
@@ -9,7 +9,7 @@ body {
   .title {
     margin-left: var(--neon-space-32);
     font-family: var(--neon-font-family-body);
-    font-weight: lighter;
+    font-weight: var(--neon-font-weight-extra-light);
   }
 }
 
@@ -30,7 +30,7 @@ header {
     margin-left: var(--neon-space-16);
     font-family: var(--neon-font-family-heading);
     font-size: var(--neon-font-size-l);
-    font-weight: var(--neon-font-weight-light);
+    font-weight: var(--neon-font-weight-extra-light);
     opacity: 0.9;
     letter-spacing: var(--neon-letter-spacing-s);
     line-height: var(--neon-line-height-one);
@@ -91,7 +91,7 @@ a[href]:not(.neon-link--no-style):not(.neon-link) {
 
   &:after {
     content: '';
-    font-weight: bold;
+    font-weight: var(--neon-font-weight-semi-bold);
     position: absolute;
     left: 0;
     bottom: 0;
@@ -108,7 +108,7 @@ a[href]:not(.neon-link--no-style):not(.neon-link) {
     color: var(--neon-color-link);
 
     &:after {
-      background-color: var(--neon-color-link);
+      font-weight: var(--neon-font-weight-semi-bold);
     }
   }
 
@@ -122,7 +122,7 @@ a[href]:not(.neon-link--no-style):not(.neon-link) {
 }
 
 .example-inverse-bg {
-  background-color: var(--neon-color-primary);
+  background-color: var(--neon-color-text-primary);
   border-radius: var(--neon-border-radius);
   padding: var(--neon-space-8);
 }

--- a/src/app/views/design/color/Color.ts
+++ b/src/app/views/design/color/Color.ts
@@ -17,15 +17,15 @@ export default defineComponent({
   setup() {
     const example = `<div class="neon-color-text">This is the default text color</div>
 <div class="color-example-inverse-bg neon-color-inverse">This is the inverse text color</div>
-<div class="neon-color-text-brand">This is the brand text color</div>
-<div class="neon-color-text-primary">This is the primary text color</div>
-<div class="neon-color-text-info">This is the info text color</div>
-<div class="neon-color-text-success">This is the success text color</div>
-<div class="neon-color-text-warn">This is the warn text color</div>
-<div class="neon-color-text-error">This is the error text color</div>
-<div class="neon-color-text-neutral">This is the neutral text color</div>
-<div class="neon-color-text-high-contrast">This is the high-contrast text color</div>
-<div class="neon-color-text-low-contrast">This is the low-contrast text color</div>`;
+<div class="neon-color-brand">This is the brand text color</div>
+<div class="neon-color-primary">This is the primary text color</div>
+<div class="neon-color-info">This is the info text color</div>
+<div class="neon-color-success">This is the success text color</div>
+<div class="neon-color-warn">This is the warn text color</div>
+<div class="neon-color-error">This is the error text color</div>
+<div class="neon-color-neutral">This is the neutral text color</div>
+<div class="neon-color-high-contrast">This is the high-contrast text color</div>
+<div class="neon-color-low-contrast">This is the low-contrast text color</div>`;
 
     const colorPalette = `  --neon-rgb-brand-l5: 251, 240, 255; // #fbf0ff
   --neon-color-brand-l5: rgb(var(--neon-rgb-brand-l5));

--- a/src/app/views/design/color/Color.vue
+++ b/src/app/views/design/color/Color.vue
@@ -287,15 +287,15 @@
             <div>
               <div class="neon-color-text">This is the default text color</div>
               <div class="color-example-inverse-bg neon-color-inverse">This is the inverse text color</div>
-              <div class="neon-color-text-brand">This is the brand text color</div>
-              <div class="neon-color-text-primary">This is the primary text color</div>
-              <div class="neon-color-text-info">This is the info text color</div>
-              <div class="neon-color-text-success">This is the success text color</div>
-              <div class="neon-color-text-warn">This is the warn text color</div>
-              <div class="neon-color-text-error">This is the error text color</div>
-              <div class="neon-color-text-neutral">This is the neutral text color</div>
-              <div class="neon-color-text-high-contrast">This is the high-contrast text color</div>
-              <div class="neon-color-text-low-contrast">This is the low-contrast text color</div>
+              <div class="neon-color-brand">This is the brand text color</div>
+              <div class="neon-color-primary">This is the primary text color</div>
+              <div class="neon-color-info">This is the info text color</div>
+              <div class="neon-color-success">This is the success text color</div>
+              <div class="neon-color-warn">This is the warn text color</div>
+              <div class="neon-color-error">This is the error text color</div>
+              <div class="neon-color-neutral">This is the neutral text color</div>
+              <div class="neon-color-high-contrast">This is the high-contrast text color</div>
+              <div class="neon-color-low-contrast">This is the low-contrast text color</div>
             </div>
             <editor v-model="example" />
           </neon-stack>

--- a/src/app/views/design/color/Colors-and-Palettes.scss
+++ b/src/app/views/design/color/Colors-and-Palettes.scss
@@ -48,10 +48,10 @@
 }
 
 .color-example-inverse-bg {
-  background-color: var(--neon-color-primary);
-  border-radius: var(--neon-border-radius);
-  margin-left: calc(-1 * var(--neon-space-4));
-  padding-left: var(--neon-space-4);
-  padding-right: var(--neon-space-4);
+  background-color: var(--neon-color-text-primary);
+  border-radius: 0;
+  margin-left: calc(-2 * var(--neon-base-space));
+  padding-left: calc(2 * var(--neon-base-space));
+  padding-right: calc(2 * var(--neon-base-space));
   width: fit-content;
 }

--- a/src/app/views/design/palette-creator/PaletteCreator.scss
+++ b/src/app/views/design/palette-creator/PaletteCreator.scss
@@ -12,8 +12,12 @@
       height: 50rem;
       top: -13rem;
       position: absolute;
-      left: 78rem;
+      left: 98rem;
       border: none;
+    }
+
+    input.neon-input__text:focus {
+      background-color: var(--neon-background-color);
     }
 
     .neon-color__input {
@@ -34,9 +38,9 @@
       & > span {
         position: absolute;
         top: -6rem;
-        left: 90rem;
+        left: 110rem;
         text-transform: uppercase;
-        font-weight: var(--neon-font-weight-semi-bold);
+        font-weight: var(--neon-font-weight-medium);
         pointer-events: none;
         touch-action: none;
       }
@@ -48,40 +52,40 @@
     .palette-creator__color--large-aaa,
     .palette-creator__color--large-aa {
       font-size: 18.66rem;
-      font-weight: bold;
-      left: 124rem;
+      font-weight: var(--neon-font-weight-semi-bold);
+      left: 144rem;
       top: 12rem;
     }
 
     .palette-creator__color--normal-aaa,
     .palette-creator__color--normal-aa {
       font-size: 16rem;
-      font-weight: normal;
-      left: 124rem;
+      font-weight: var(--neon-font-weight-normal);
+      left: 144rem;
     }
   }
 
   .palette-creator__dark-palette {
     .palette-creator__color--large-aaa,
     .palette-creator__color--large-aa {
-      color: var(--neon-color-text-strong-light);
+      color: var(--neon-color-text-primary-dark);
     }
 
     .palette-creator__color--normal-aaa,
     .palette-creator__color--normal-aa {
-      color: var(--neon-color-text-light);
+      color: var(--neon-color-text-secondary-dark);
     }
   }
 
   .palette-creator__light-palette {
     .palette-creator__color--large-aaa,
     .palette-creator__color--large-aa {
-      color: var(--neon-color-text-strong-dark);
+      color: var(--neon-color-text-primary-light);
     }
 
     .palette-creator__color--normal-aaa,
     .palette-creator__color--normal-aa {
-      color: var(--neon-color-text-dark);
+      color: var(--neon-color-text-secondary-light);
     }
   }
 
@@ -106,12 +110,12 @@
     padding-bottom: 1rem;
     margin-bottom: 0 !important;
     background-color: black;
-    color: var(--neon-color-text-strong-dark);
+    color: var(--neon-color-text-primary-light);
   }
 
   .palette-creator__dark-palette {
     padding-top: 5rem;
     background-color: white;
-    color: var(--neon-color-text-strong-light);
+    color: var(--neon-color-text-primary-dark);
   }
 }

--- a/src/app/views/design/palette-creator/PaletteCreator.ts
+++ b/src/app/views/design/palette-creator/PaletteCreator.ts
@@ -33,10 +33,12 @@ export default defineComponent({
   },
   setup() {
     const keys = [
-      '--neon-rgb-text-dark',
-      '--neon-rgb-text-strong-dark',
-      '--neon-rgb-text-light',
-      '--neon-rgb-text-strong-light',
+      '--neon-rgb-text-primary-light',
+      '--neon-rgb-text-secondary-light',
+      '--neon-rgb-text-tertiary-light',
+      '--neon-rgb-text-primary-dark',
+      '--neon-rgb-text-secondary-dark',
+      '--neon-rgb-text-tertiary-dark',
       '--neon-rgb-disabled-background-dark',
       '--neon-rgb-disabled-border-dark',
       '--neon-rgb-disabled-text-dark',
@@ -160,8 +162,8 @@ export default defineComponent({
     };
 
     const generatePalette = (colorPaletteKey: string, color: string) => {
-      const darkText = palette.value['--neon-rgb-text-dark'];
-      const lightText = palette.value['--neon-rgb-text-light'];
+      const darkText = palette.value['--neon-rgb-text-secondary-light'];
+      const lightText = palette.value['--neon-rgb-text-secondary-dark'];
       const newPalette = NeonColorUtils.generatePalette(color, darkText, lightText);
       Object.entries(newPalette).forEach(([key, value]) => {
         const colorKey = `--neon-rgb-${colorPaletteKey}-${key}`;
@@ -179,13 +181,13 @@ export default defineComponent({
         if (key.indexOf('text') === -1) {
           const isDark = key[key.length - 2] === 'd';
           const accessibleNormal = NeonColorUtils.isAccessible(
-            palette.value[isDark ? '--neon-rgb-text-light' : '--neon-rgb-text-dark'],
+            palette.value[isDark ? '--neon-rgb-text-secondary-dark' : '--neon-rgb-text-secondary-light'],
             value,
           );
           const { normalAA, normalAAA } = accessibleNormal;
 
           const accessibleLarge = NeonColorUtils.isAccessible(
-            palette.value[isDark ? '--neon-rgb-text-strong-light' : '--neon-rgb-text-strong-dark'],
+            palette.value[isDark ? '--neon-rgb-text-primary-dark' : '--neon-rgb-text-primary-light'],
             value,
           );
           const { largeAA, largeAAA } = accessibleLarge;

--- a/src/app/views/design/palette-creator/PaletteCreator.vue
+++ b/src/app/views/design/palette-creator/PaletteCreator.vue
@@ -18,10 +18,16 @@
       </neon-card-body>
       <neon-card-footer>
         <div class="neon-button-group">
-          <neon-button button-style="text" label="Reset palette" size="s" @click="openConfirmResetDialog = true" />
+          <neon-button
+            button-style="text"
+            color="low-contrast"
+            label="Reset palette"
+            size="s"
+            @click="openConfirmResetDialog = true"
+          />
           <neon-button
             color="brand"
-            icon="download"
+            icon="download-button"
             icon-position="right"
             label="Export colors"
             size="s"
@@ -43,70 +49,70 @@
     </neon-card>
     <neon-card>
       <neon-card-body class="palette-creator__text-vars">
-        <h2 class="neon-h4">Text variables</h2>
+        <h2 class="neon-h4">Light mode text</h2>
         <neon-inline>
-          <neon-field for="textDark" label="Text dark">
+          <neon-field for="textPrimaryLight" label="Text primary light">
             <neon-color
-              id="textDark"
-              :model-value="palette['--neon-rgb-text-dark']"
-              @update:modelValue="setStyle('--neon-rgb-text-dark', $event)"
+              id="textPrimaryLight"
+              :model-value="palette['--neon-rgb-text-primary-light']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-primary-light', $event)"
             />
           </neon-field>
-          <neon-field for="textDarkStrong" label="Text dark strong">
+          <neon-field for="textSecondaryLight" label="Text secondary light">
             <neon-color
-              id="textDarkStrong"
-              :model-value="palette['--neon-rgb-text-strong-dark']"
-              @update:modelValue="setStyle('--neon-rgb-text-strong-dark', $event)"
+              id="textSecondaryLight"
+              :model-value="palette['--neon-rgb-text-secondary-light']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-secondary-light', $event)"
+            />
+          </neon-field>
+          <neon-field for="textTertiaryLight" label="Text tertiary light">
+            <neon-color
+              id="textTertiaryLight"
+              :model-value="palette['--neon-rgb-text-tertiary-light']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-tertiary-light', $event)"
             />
           </neon-field>
         </neon-inline>
+        <br />
+        <h2 class="neon-h4">Dark mode text</h2>
         <neon-inline>
-          <neon-field for="textLight" label="Text light">
+          <neon-field for="textPrimaryDark" label="Text primary dark">
             <neon-color
-              id="textLight"
-              :model-value="palette['--neon-rgb-text-light']"
-              @update:modelValue="setStyle('--neon-rgb-text-light', $event)"
+              id="textPrimaryDark"
+              :model-value="palette['--neon-rgb-text-primary-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-primary-dark', $event)"
             />
           </neon-field>
-          <neon-field for="textLightStrong" label="Text light strong">
+          <neon-field for="textSecondaryDark" label="Text secondary dark">
             <neon-color
-              id="textLightStrong"
-              :model-value="palette['--neon-rgb-text-strong-light']"
-              @update:modelValue="setStyle('--neon-rgb-text-strong-light', $event)"
+              id="textSecondaryDark"
+              :model-value="palette['--neon-rgb-text-secondary-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-secondary-dark', $event)"
+            />
+          </neon-field>
+          <neon-field for="textTertiaryDark" label="Text tertiary dark">
+            <neon-color
+              id="textTertiaryDark"
+              :model-value="palette['--neon-rgb-text-tertiary-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-text-tertiary-dark', $event)"
             />
           </neon-field>
         </neon-inline>
       </neon-card-body>
       <neon-card-body class="palette-creator__text-vars">
-        <h2 class="neon-h4">Disabled variables</h2>
-        <neon-inline breakpoint="tablet">
-          <neon-field for="disabledBackgroundDark" label="Disabled bg dark">
-            <neon-color
-              id="disabledBackgroundDark"
-              :model-value="palette['--neon-rgb-disabled-background-dark']"
-              @update:modelValue="setStyle('--neon-rgb-disabled-background-dark', $event)"
-            />
-          </neon-field>
-          <neon-field for="disabledBorderDark" label="Disabled border dark">
-            <neon-color
-              id="disabledBorderDark"
-              :model-value="palette['--neon-rgb-disabled-border-dark']"
-              @update:modelValue="setStyle('--neon-rgb-disabled-border-dark', $event)"
-            />
-          </neon-field>
-          <neon-field for="disabledTextDark" label="Disabled text dark">
-            <neon-color
-              id="disabledTextDark"
-              :model-value="palette['--neon-rgb-disabled-text-dark']"
-              @update:modelValue="setStyle('--neon-rgb-disabled-text-dark', $event)"
-            />
-          </neon-field>
-        </neon-inline>
+        <h2 class="neon-h4">Light mode disabled variables</h2>
         <neon-inline breakpoint="tablet">
           <neon-field for="disabledBackgroundLight" label="Disabled bg light">
             <neon-color
               id="disabledBackgroundLight"
               :model-value="palette['--neon-rgb-disabled-background-light']"
+              color="low-contrast"
               @update:modelValue="setStyle('--neon-rgb-disabled-background-light', $event)"
             />
           </neon-field>
@@ -114,6 +120,7 @@
             <neon-color
               id="disabledBorderLight"
               :model-value="palette['--neon-rgb-disabled-border-light']"
+              color="low-contrast"
               @update:modelValue="setStyle('--neon-rgb-disabled-border-light', $event)"
             />
           </neon-field>
@@ -121,7 +128,36 @@
             <neon-color
               id="disabledTextLight"
               :model-value="palette['--neon-rgb-disabled-text-light']"
+              color="low-contrast"
               @update:modelValue="setStyle('--neon-rgb-disabled-text-light', $event)"
+            />
+          </neon-field>
+        </neon-inline>
+        <br />
+        <h2 class="neon-h4">Dark mode disabled variables</h2>
+        <neon-inline breakpoint="tablet">
+          <neon-field for="disabledBackgroundDark" label="Disabled bg dark">
+            <neon-color
+              id="disabledBackgroundDark"
+              :model-value="palette['--neon-rgb-disabled-background-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-disabled-background-dark', $event)"
+            />
+          </neon-field>
+          <neon-field for="disabledBorderDark" label="Disabled border dark">
+            <neon-color
+              id="disabledBorderDark"
+              :model-value="palette['--neon-rgb-disabled-border-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-disabled-border-dark', $event)"
+            />
+          </neon-field>
+          <neon-field for="disabledTextDark" label="Disabled text dark">
+            <neon-color
+              id="disabledTextDark"
+              :model-value="palette['--neon-rgb-disabled-text-dark']"
+              color="low-contrast"
+              @update:modelValue="setStyle('--neon-rgb-disabled-text-dark', $event)"
             />
           </neon-field>
         </neon-inline>
@@ -144,74 +180,78 @@
             class="palette-creator__palette-group"
           >
             <h3 class="neon-h5">{{ neutralPalette }}</h3>
-            <div class="palette-creator__light-palette">
-              <div v-for="step in stepsLight" :key="`${neutralPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${neutralPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${neutralPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+            <div>
+              <div class="palette-creator__light-palette">
+                <div v-for="step in stepsLight" :key="`${neutralPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${neutralPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${neutralPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
-            </div>
-            <div class="palette-creator__dark-palette">
-              <div v-for="step in stepsDark" :key="`${neutralPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${neutralPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${neutralPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+              <div class="palette-creator__dark-palette">
+                <div v-for="step in stepsDark" :key="`${neutralPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${neutralPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${neutralPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${neutralPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${neutralPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
             </div>
           </neon-stack>
@@ -235,78 +275,83 @@
               <neon-color
                 :model-value="palette[`--neon-rgb-${brandPalette}-l1`]"
                 class="palette-creator__select-reference"
+                color="low-contrast"
                 size="s"
                 @update:modelValue="generatePalette(brandPalette, $event)"
               />
             </neon-field>
-            <div class="palette-creator__light-palette">
-              <div v-for="step in stepsLight" :key="`${brandPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${brandPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${brandPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+            <div>
+              <div class="palette-creator__light-palette">
+                <div v-for="step in stepsLight" :key="`${brandPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${brandPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${brandPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
-            </div>
-            <div class="palette-creator__dark-palette">
-              <div v-for="step in stepsDark" :key="`${brandPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${brandPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${brandPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+              <div class="palette-creator__dark-palette">
+                <div v-for="step in stepsDark" :key="`${brandPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${brandPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${brandPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${brandPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${brandPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
             </div>
           </neon-stack>
@@ -334,78 +379,83 @@
               <neon-color
                 :model-value="palette[`--neon-rgb-${functionalPalette}-l1`]"
                 class="palette-creator__select-reference"
+                color="low-contrast"
                 size="s"
                 @update:modelValue="generatePalette(functionalPalette, $event)"
               />
             </neon-field>
-            <div class="palette-creator__light-palette">
-              <div v-for="step in stepsLight" :key="`${functionalPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${functionalPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${functionalPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+            <div>
+              <div class="palette-creator__light-palette">
+                <div v-for="step in stepsLight" :key="`${functionalPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${functionalPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${functionalPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
-            </div>
-            <div class="palette-creator__dark-palette">
-              <div v-for="step in stepsDark" :key="`${functionalPalette}-${step}`">
-                <neon-color
-                  :model-value="palette[`--neon-rgb-${functionalPalette}-${step}`]"
-                  @update:modelValue="setStyle(`--neon-rgb-${functionalPalette}-${step}`, $event)"
-                />
-                <span class="palette-creator__color-level">{{ step }}</span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].large === 'AAA'
-                      ? 'palette-creator__color--large-aaa'
-                      : 'palette-creator__color--large-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].large ||
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioLarge
-                  }}
-                </span>
-                <span
-                  v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
-                  :class="
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal === 'AAA'
-                      ? 'palette-creator__color--normal-aaa'
-                      : 'palette-creator__color--normal-aa'
-                  "
-                >
-                  {{
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal ||
-                    accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioNormal
-                  }}
-                </span>
+              <div class="palette-creator__dark-palette">
+                <div v-for="step in stepsDark" :key="`${functionalPalette}-${step}`">
+                  <neon-color
+                    :model-value="palette[`--neon-rgb-${functionalPalette}-${step}`]"
+                    color="low-contrast"
+                    @update:modelValue="setStyle(`--neon-rgb-${functionalPalette}-${step}`, $event)"
+                  />
+                  <span class="palette-creator__color-level">{{ step }}</span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].large === 'AAA'
+                        ? 'palette-creator__color--large-aaa'
+                        : 'palette-creator__color--large-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].large ||
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioLarge
+                    }}
+                  </span>
+                  <span
+                    v-if="accessibility[`--neon-rgb-${functionalPalette}-${step}`]"
+                    :class="
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal === 'AAA'
+                        ? 'palette-creator__color--normal-aaa'
+                        : 'palette-creator__color--normal-aa'
+                    "
+                  >
+                    {{
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].normal ||
+                      accessibility[`--neon-rgb-${functionalPalette}-${step}`].ratioNormal
+                    }}
+                  </span>
+                </div>
               </div>
             </div>
           </neon-stack>

--- a/src/app/views/error/NotFound.scss
+++ b/src/app/views/error/NotFound.scss
@@ -14,7 +14,7 @@
 
   h1 {
     font-size: 20vw;
-    font-weight: var(--neon-font-weight-bold);
+    font-weight: var(--neon-font-weight-semi-bold);
     color: var(--app-color-404);
 
     @include responsive.responsive(tablet) {
@@ -23,7 +23,7 @@
   }
 
   h2 {
-    font-weight: var(--neon-font-weight-bold);
+    font-weight: var(--neon-font-weight-semi-bold);
   }
 
   p {

--- a/src/app/views/feedback/alert/Alert.vue
+++ b/src/app/views/feedback/alert/Alert.vue
@@ -21,10 +21,10 @@
         </neon-card-header>
         <neon-card-body>
           <neon-inline>
-            <neon-button label="Top left" @click="infoAlert(NeonAlertPlacement.TopLeft)" />
-            <neon-button label="Top right" @click="infoAlert(NeonAlertPlacement.TopRight)" />
-            <neon-button label="Bottom left" @click="infoAlert(NeonAlertPlacement.BottomLeft)" />
-            <neon-button label="Bottom right" @click="infoAlert(NeonAlertPlacement.BottomRight)" />
+            <neon-button color="low-contrast" label="Top left" @click="infoAlert(NeonAlertPlacement.TopLeft)" />
+            <neon-button color="low-contrast" label="Top right" @click="infoAlert(NeonAlertPlacement.TopRight)" />
+            <neon-button color="low-contrast" label="Bottom left" @click="infoAlert(NeonAlertPlacement.BottomLeft)" />
+            <neon-button color="low-contrast" label="Bottom right" @click="infoAlert(NeonAlertPlacement.BottomRight)" />
           </neon-inline>
         </neon-card-body>
         <neon-card-body>
@@ -35,8 +35,8 @@
         </neon-card-header>
         <neon-card-body>
           <neon-inline>
-            <neon-button label="Single action" @click="alertSingleAction()" />
-            <neon-button label="Both actions" @click="alertBothActions()" />
+            <neon-button color="low-contrast" label="Single action" @click="alertSingleAction()" />
+            <neon-button color="low-contrast" label="Both actions" @click="alertBothActions()" />
           </neon-inline>
         </neon-card-body>
         <neon-card-body>
@@ -48,8 +48,8 @@
         <neon-card-body>
           <neon-stack>
             <neon-inline>
-              <neon-button label="Toast top" @click="toastInfo()" />
-              <neon-button label="Toast bottom" @click="toastInfo(NeonVerticalPosition.Bottom)" />
+              <neon-button color="low-contrast" label="Toast top" @click="toastInfo()" />
+              <neon-button color="low-contrast" label="Toast bottom" @click="toastInfo(NeonVerticalPosition.Bottom)" />
             </neon-inline>
             <neon-inline breakpoint="tablet">
               <neon-button color="info" label="Toast info" @click="toastInfo()" />

--- a/src/app/views/feedback/dialog/AppDialog.vue
+++ b/src/app/views/feedback/dialog/AppDialog.vue
@@ -10,7 +10,7 @@
       <neon-card-body>
         <h2 class="neon-h3">Dialog example</h2>
         <neon-stack gap="m">
-          <neon-button label="Open dialog" @click="toggleOpen(true)"></neon-button>
+          <neon-button color="low-contrast" label="Open dialog" @click="toggleOpen(true)"></neon-button>
           <neon-dialog
             :open="open"
             cancel-label="Reject"

--- a/src/app/views/feedback/linear-progress/LinearProgress.vue
+++ b/src/app/views/feedback/linear-progress/LinearProgress.vue
@@ -14,17 +14,17 @@
             <h4 class="neon-h5">Percentage</h4>
             <neon-inline>
               <neon-linear-progress :model-value="progressPercentage" />
-              <neon-button label="Complete" size="s" @click="progressPercentage = 1.0" />
+              <neon-button color="low-contrast" label="Complete" size="s" @click="progressPercentage = 1.0" />
             </neon-inline>
             <h4 class="neon-h5">Counter</h4>
             <neon-inline>
               <neon-linear-progress :model-value="progressCounter" :total="55" />
-              <neon-button label="Complete" size="s" @click="progressCounter = 55" />
+              <neon-button color="low-contrast" label="Complete" size="s" @click="progressCounter = 55" />
             </neon-inline>
             <h4 class="neon-h5">No output</h4>
             <neon-inline>
               <neon-linear-progress :model-value="progressNoOutput" :output="false" :total="55" />
-              <neon-button label="Complete" size="s" @click="progressNoOutput = 55" />
+              <neon-button color="low-contrast" label="Complete" size="s" @click="progressNoOutput = 55" />
             </neon-inline>
             <h4 class="neon-h5">With label</h4>
             <neon-inline>

--- a/src/app/views/feedback/splash-loader/SplashLoader.vue
+++ b/src/app/views/feedback/splash-loader/SplashLoader.vue
@@ -14,7 +14,7 @@
         <h2 class="neon-h3">Splash loader example</h2>
         <neon-stack>
           <neon-stack>
-            <neon-button label="Show loader" @click="openLoader()" />
+            <neon-button color="low-contrast" label="Show loader" @click="openLoader()" />
             <neon-splash-loader v-if="open" :fullscreen="true" :overlay="true" color="brand" size="xl" />
           </neon-stack>
           <editor v-model="template" />

--- a/src/app/views/feedback/tooltip/Tooltip.vue
+++ b/src/app/views/feedback/tooltip/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <component-documentation v-if="menuModel" :model="menuModel" :headline="headline">
+  <component-documentation v-if="menuModel" :headline="headline" :model="menuModel">
     <neon-card>
       <neon-card-body>
         <neon-stack>
@@ -33,7 +33,7 @@
                   <strong>me</strong>
                 </template>
                 <template #content>
-                  <span class="neon-h6" role="heading" aria-level="6">Popover content</span>
+                  <span aria-level="6" class="neon-h6" role="heading">Popover content</span>
                   <p>
                     Spicy jalapeno bacon ipsum dolor amet biltong porchetta cupim sausage pork loin. Ham porchetta
                     brisket, kielbasa ham hock sirloin ground round strip steak jowl jerky short ribs pork loin
@@ -44,12 +44,12 @@
               to see the popover style.
             </p>
             <br />
-            <neon-tooltip tooltip-style="popover" outline-style="border" outline-color="low-contrast">
+            <neon-tooltip outline-color="low-contrast" outline-style="border" tooltip-style="popover">
               <template #target>
-                <neon-button size="s" label="Hover me" />
+                <neon-button color="low-contrast" label="Hover me" size="s" />
               </template>
               <template #content>
-                <span class="neon-h6" role="heading" aria-level="6">Popover content</span>
+                <span aria-level="6" class="neon-h6" role="heading">Popover content</span>
                 <p>
                   Spicy jalapeno bacon ipsum dolor amet biltong porchetta cupim sausage pork loin. Ham porchetta
                   brisket, kielbasa ham hock sirloin ground round strip steak jowl jerky short ribs pork loin
@@ -74,8 +74,9 @@
                 </template>
                 <template #content>
                   <span>Tooltip content</span>
-                </template> </neon-tooltip
-              >.
+                </template>
+              </neon-tooltip>
+              .
             </p>
             <!-- left -->
             <p>
@@ -86,8 +87,9 @@
                 </template>
                 <template #content>
                   <span>Tooltip content</span>
-                </template> </neon-tooltip
-              >.
+                </template>
+              </neon-tooltip>
+              .
             </p>
             <!-- bottom -->
             <p>
@@ -98,8 +100,9 @@
                 </template>
                 <template #content>
                   <span>Tooltip content</span>
-                </template> </neon-tooltip
-              >.
+                </template>
+              </neon-tooltip>
+              .
             </p>
             <!-- right -->
             <p>
@@ -110,8 +113,9 @@
                 </template>
                 <template #content>
                   <span>Tooltip content</span>
-                </template> </neon-tooltip
-              >.
+                </template>
+              </neon-tooltip>
+              .
             </p>
           </div>
           <editor v-model="placementTemplate" />

--- a/src/app/views/home/Home.scss
+++ b/src/app/views/home/Home.scss
@@ -37,7 +37,7 @@
   }
 
   .powered-by {
-    font-weight: var(--neon-font-weight-light);
+    font-weight: var(--neon-font-weight-extra-light);
     margin-top: var(--neon-space-40);
     text-align: center;
   }

--- a/src/app/views/home/Home.vue
+++ b/src/app/views/home/Home.vue
@@ -124,7 +124,7 @@
           />
         </div>
       </div>
-      <span class="powered-by neon-color-text-neutral">
+      <span class="powered-by neon-color-neutral">
         This site was developed using
         <neon-link href="https://vuejs.org/" target="_blank">Vue</neon-link> and Neon o‿o
       </span>

--- a/src/app/views/layout/card-list/CardList.scss
+++ b/src/app/views/layout/card-list/CardList.scss
@@ -1,6 +1,6 @@
 .card-contents {
   .card-title {
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
     font-size: var(--neon-font-size-s);
   }
 

--- a/src/app/views/layout/card-list/CardList.ts
+++ b/src/app/views/layout/card-list/CardList.ts
@@ -32,7 +32,7 @@ export default defineComponent({
   <template #card="{ cardModel, index }">
     <neon-stack gap="s">
       <h6>{{ cardModel.title }}</h6>
-      <span class="neon-color-text-low-contrast">{{ cardModel.description }}</span>
+      <span class="neon-color-low-contrast">{{ cardModel.description }}</span>
     </neon-stack>
   </template>
 </neon-card-list>`;

--- a/src/app/views/layout/card/Card.vue
+++ b/src/app/views/layout/card/Card.vue
@@ -50,7 +50,7 @@
               <p>Place card actions inside the <strong>NeonCardFooter</strong> below:</p>
             </neon-card-body>
             <neon-card-footer>
-              <neon-button label="Cancel" />
+              <neon-button color="low-contrast" label="Cancel" />
               <neon-button color="primary" label="Accept" />
             </neon-card-footer>
           </neon-card>
@@ -70,7 +70,7 @@
               </p>
             </neon-card-body>
             <neon-card-footer>
-              <neon-button label="Cancel" size="s" />
+              <neon-button color="low-contrast" label="Cancel" size="s" />
               <neon-button color="primary" label="Accept" size="s" />
             </neon-card-footer>
           </neon-card>

--- a/src/app/views/layout/drawer/Drawer.vue
+++ b/src/app/views/layout/drawer/Drawer.vue
@@ -14,26 +14,31 @@
         <neon-stack>
           <neon-inline gap="m">
             <!-- Left -->
-            <neon-button label="Open left" @click="onOpenLeft(true)"></neon-button>
+            <neon-button color="low-contrast" label="Open left" @click="onOpenLeft(true)"></neon-button>
             <neon-drawer :open="openLeft" position="left" @close="onOpenLeft(false)">
               <div v-html="contents"></div>
             </neon-drawer>
             <!-- Right -->
-            <neon-button label="Open right" @click="onOpenRight(true)"></neon-button>
+            <neon-button color="low-contrast" label="Open right" @click="onOpenRight(true)"></neon-button>
             <neon-drawer :open="openRight" position="right" @close="onOpenRight(false)">
               <div v-html="contents"></div>
             </neon-drawer>
             <!-- Top (overlay = false) -->
-            <neon-button label="Open top" @click="onOpenTop(true)"></neon-button>
+            <neon-button color="low-contrast" label="Open top" @click="onOpenTop(true)"></neon-button>
             <neon-drawer :open="openTop" :overlay="false" position="top" @close="onOpenTop(false)">
               <div v-html="contents"></div>
             </neon-drawer>
             <!-- Bottom -->
-            <neon-button label="Open bottom" @click="onOpenBottom(true)"></neon-button>
+            <neon-button color="low-contrast" label="Open bottom" @click="onOpenBottom(true)"></neon-button>
             <neon-drawer :dismissible="false" :open="openBottom" position="bottom">
               <div v-html="contents"></div>
               <br />
-              <neon-button label="Close" style="align-self: flex-end" @click="onOpenBottom(false)" />
+              <neon-button
+                color="low-contrast"
+                label="Close"
+                style="align-self: flex-end"
+                @click="onOpenBottom(false)"
+              />
             </neon-drawer>
           </neon-inline>
           <editor v-model="template" />

--- a/src/app/views/layout/modal/Modal.vue
+++ b/src/app/views/layout/modal/Modal.vue
@@ -11,7 +11,7 @@
         <h2 class="neon-h3">Modal example</h2>
         <neon-stack>
           <neon-inline>
-            <neon-button label="Open modal" @click="toggleOpen(true)"></neon-button>
+            <neon-button color="low-contrast" label="Open modal" @click="toggleOpen(true)"></neon-button>
             <neon-modal :open="open" @close="toggleOpen(false)">
               <neon-card size="m">
                 <neon-card-header>
@@ -27,7 +27,7 @@
                   </p>
                 </neon-card-body>
                 <neon-card-footer>
-                  <neon-button button-style="text" label="Cancel" @click="toggleOpen(false)" />
+                  <neon-button button-style="text" color="low-contrast" label="Cancel" @click="toggleOpen(false)" />
                   <neon-button color="primary" label="Accept" @click="toggleOpen(false)" />
                 </neon-card-footer>
               </neon-card>

--- a/src/app/views/presentation/icon/Icon.vue
+++ b/src/app/views/presentation/icon/Icon.vue
@@ -29,7 +29,7 @@
               </p>
               <p>
                 There is an icon registry where strings containing SVGs can be registered with a name and that name can
-                be used with the NeonIcon component to render the image. Use the classes <em>neon-svg-fill</em> and
+                be used with the NeonIcon component to render the image. Use the classes <em>neon-svg--fill</em> and
                 <em>neon-svg--stroke</em> in the SVG elements to automatically apply the functional colors.
               </p>
               <p>

--- a/src/app/views/source/Source.scss
+++ b/src/app/views/source/Source.scss
@@ -21,7 +21,7 @@
 
   &__property-value {
     font-family: var(--neon-font-family-monospaced);
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
     color: var(--neon-color-info);
   }
 
@@ -39,7 +39,7 @@
 
   &__param-name {
     font-family: var(--neon-font-family-monospaced);
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
     color: var(--neon-color-neutral);
   }
 

--- a/src/app/views/user-input/field-group/FieldGroup.vue
+++ b/src/app/views/user-input/field-group/FieldGroup.vue
@@ -29,7 +29,7 @@
             <neon-field-group>
               <neon-input-indicator label="$" size="l" />
               <neon-input v-model="indexFilter" placeholder="Enter amount" size="l" type="text" />
-              <neon-button label="Submit" size="l" />
+              <neon-button color="low-contrast" label="Submit" size="l" />
             </neon-field-group>
           </neon-stack>
           <editor v-model="inputIndicatorExamples" />

--- a/src/app/views/user-input/toggle/Toggle.ts
+++ b/src/app/views/user-input/toggle/Toggle.ts
@@ -105,7 +105,7 @@ export default defineComponent({
   <template #option="{ option, index }">
     <neon-stack gap="s">
       <span v-if="option.label">{{ option.label }}</span>
-      <span v-if="option.description" class="neon-color-text-low-contrast">
+      <span v-if="option.description" class="neon-color-low-contrast">
         {{ option.description }}
       </span>
     </neon-stack>

--- a/src/app/views/user-input/toggle/Toggle.vue
+++ b/src/app/views/user-input/toggle/Toggle.vue
@@ -66,7 +66,7 @@
               <template #option="{ option, index }">
                 <neon-stack gap="s">
                   <span v-if="option.label">{{ option.label }}</span>
-                  <span v-if="option.description" class="neon-color-text-low-contrast">
+                  <span v-if="option.description" class="neon-color-low-contrast">
                     {{ option.description }}
                   </span>
                 </neon-stack>

--- a/src/components/feedback/dialog/NeonDialog.vue
+++ b/src/components/feedback/dialog/NeonDialog.vue
@@ -7,7 +7,14 @@
           <div class="neon-dialog__question" v-html="question"></div>
         </div>
         <div ref="actions">
-          <neon-button :aria-label="cancelLabel" :full-width="true" :label="cancelLabel" size="s" @click="cancel()" />
+          <neon-button
+            :aria-label="cancelLabel"
+            :full-width="true"
+            :label="cancelLabel"
+            color="low-contrast"
+            size="s"
+            @click="cancel()"
+          />
           <neon-button
             :alternate-color="alternateColor"
             :aria-label="confirmLabel"

--- a/src/components/feedback/note/NeonNote.vue
+++ b/src/components/feedback/note/NeonNote.vue
@@ -24,6 +24,7 @@
       :transparent="true"
       button-style="text"
       class="neon-note__close"
+      color="low-contrast"
       icon="times"
       size="s"
       tabindex="0"

--- a/src/components/presentation/icon/NeonIcon.ts
+++ b/src/components/presentation/icon/NeonIcon.ts
@@ -9,7 +9,7 @@ import type { NeonFunctionalColor } from '@/common/enums/NeonFunctionalColor';
  * components. But you may also find it useful for rendering SVG images, e.g. illustrations.</p>
  *
  * <p>There is an icon registry where strings containing SVGs can be registered with a name and that name can be used
- * with the NeonIcon component to render the image. Use the classes <em>neon-svg-fill</em> and <em>neon-svg--stroke</em>
+ * with the NeonIcon component to render the image. Use the classes <em>neon-svg--fill</em> and <em>neon-svg--stroke</em>
  * in the SVG elements to automatically apply the functional colors.</p>
  *
  * <p>This provides the advantage of only registering the icons you actually need, dynamically switching colors in

--- a/src/components/user-input/field/NeonField.spec.ts
+++ b/src/components/user-input/field/NeonField.spec.ts
@@ -54,7 +54,7 @@ describe('NeonField', () => {
     const message = 'Bacon ipsum dolor amet venison';
     const { container, getByText } = render(NeonField, { props: { label, optional: true, message } });
     getByText(message);
-    expect(container.querySelector('.neon-field__message .neon-color-text-low-contrast')).toBeDefined();
+    expect(container.querySelector('.neon-field__message .neon-color-low-contrast')).toBeDefined();
   });
 
   it('renders error message', () => {
@@ -68,6 +68,6 @@ describe('NeonField', () => {
       },
     });
     getByText(message);
-    expect(container.querySelector('.neon-field__message .neon-color-text-error')).toBeDefined();
+    expect(container.querySelector('.neon-field__message .neon-color-error')).toBeDefined();
   });
 });

--- a/src/components/user-input/field/NeonField.vue
+++ b/src/components/user-input/field/NeonField.vue
@@ -17,7 +17,7 @@
       <slot></slot>
       <span
         v-if="message !== null"
-        :class="`neon-color-text-${messageColor}`"
+        :class="`neon-color-${messageColor}`"
         class="neon-field__message"
         @click.prevent.stop=""
       >

--- a/src/components/user-input/file/NeonFile.vue
+++ b/src/components/user-input/file/NeonFile.vue
@@ -34,6 +34,7 @@
         :disabled="disabled || files.length === 0"
         :size="size"
         button-style="text"
+        color="low-contrast"
         label="Clear all"
         @click="clearAll()"
       />

--- a/src/sass/color-variables.scss
+++ b/src/sass/color-variables.scss
@@ -1,9 +1,11 @@
 .neon {
-  --neon-color-text-dark: rgb(var(--neon-rgb-text-dark));
-  --neon-color-text-strong-dark: rgb(var(--neon-rgb-text-strong-dark));
+  --neon-color-text-primary-light: rgb(var(--neon-rgb-text-primary-light));
+  --neon-color-text-secondary-light: rgb(var(--neon-rgb-text-secondary-light));
+  --neon-color-text-tertiary-light: rgb(var(--neon-rgb-text-tertiary-light));
 
-  --neon-color-text-light: rgb(var(--neon-rgb-text-light));
-  --neon-color-text-strong-light: rgb(var(--neon-rgb-text-strong-light));
+  --neon-color-text-primary-dark: rgb(var(--neon-rgb-text-primary-dark));
+  --neon-color-text-secondary-dark: rgb(var(--neon-rgb-text-secondary-dark));
+  --neon-color-text-tertiary-dark: rgb(var(--neon-rgb-text-tertiary-dark));
 
   --neon-color-disabled-background-dark: rgb(var(--neon-rgb-disabled-background-dark));
   --neon-color-disabled-border-dark: rgb(var(--neon-rgb-disabled-border-dark));

--- a/src/sass/components/_action-menu.scss
+++ b/src/sass/components/_action-menu.scss
@@ -50,7 +50,7 @@
 
       &-count {
         font-variant: tabular-nums;
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
       }
 
       .neon-link__label {

--- a/src/sass/components/_alert-container.scss
+++ b/src/sass/components/_alert-container.scss
@@ -129,7 +129,7 @@
     &__title {
       line-height: var(--neon-line-height-one);
       font-size: var(--neon-font-size-m);
-      font-weight: var(--neon-font-weight-bold);
+      font-weight: var(--neon-font-weight-semi-bold);
       font-family: var(--neon-font-family-heading);
       letter-spacing: var(--neon-letter-spacing-m);
     }
@@ -151,7 +151,7 @@
         align-items: center;
         width: var(--neon-width-alert-action);
         justify-content: center;
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
 
         &:focus {
           border-radius: 0;

--- a/src/sass/components/_badge.scss
+++ b/src/sass/components/_badge.scss
@@ -9,7 +9,7 @@
           $neon-badge-color: var(--neon-color-#{$color});
           color: var(--neon-color-inverse);
           @if ($color == high-contrast) {
-            $neon-badge-color: var(--neon-color-text);
+            $neon-badge-color: var(--neon-color-text-secondary);
           }
 
           background: $neon-badge-color;
@@ -79,7 +79,7 @@
     }
 
     text-transform: uppercase;
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
     letter-spacing: var(--neon-letter-spacing-m);
     display: flex;
     justify-content: center;

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -57,7 +57,7 @@
   &:hover:not(:disabled),
   &:active:not(:disabled) {
     @if ($color == 'inverse') {
-      @include svg.color-with-svg(var(--neon-color-text));
+      @include svg.color-with-svg(var(--neon-color-text-secondary));
     } @else {
       @include svg.color-with-svg(var(--neon-color-inverse));
     }

--- a/src/sass/components/_card-list.scss
+++ b/src/sass/components/_card-list.scss
@@ -52,14 +52,14 @@
       white-space: nowrap;
       user-select: none;
       font-size: var(--neon-font-size-l);
-      font-weight: var(--neon-font-weight-semi-bold);
+      font-weight: var(--neon-font-weight-medium);
       width: 30%;
       text-align: right;
       margin-left: auto;
     }
 
     &__card {
-      color: var(--neon-color-text);
+      color: var(--neon-color-text-secondary);
       --neon-border-radius-card: var(--neon-border-radius-card-list);
       user-select: none;
       box-shadow: var(--neon-box-shadow-card-list);

--- a/src/sass/components/_date-picker.scss
+++ b/src/sass/components/_date-picker.scss
@@ -114,7 +114,7 @@
         border-radius: 50%;
         font-size: var(--neon-font-size-s);
         cursor: pointer;
-        color: var(--neon-color-text-strong);
+        color: var(--neon-color-text-primary);
         background-color: transparent;
 
         &--empty {
@@ -140,7 +140,7 @@
         max-width: 88rem;
         font-size: var(--neon-font-size-s);
         cursor: pointer;
-        color: var(--neon-color-text-strong);
+        color: var(--neon-color-text-primary);
         background-color: transparent;
 
         &.neon-date-picker__calendar-option--disabled {
@@ -152,7 +152,7 @@
 
     .neon-date-picker__calendar-title-readonly {
       align-self: center;
-      font-weight: var(--neon-font-weight-semi-bold);
+      font-weight: var(--neon-font-weight-medium);
     }
 
     @each $color in palettes.$neon-functional-colors {
@@ -161,7 +161,7 @@
         .neon-date-picker__calendar-options .neon-date-picker__calendar-option--today {
           color: var(--neon-color-#{$color});
           background-color: rgba(var(--neon-rgb-#{$color}), 0.125);
-          font-weight: var(--neon-font-weight-bold);
+          font-weight: var(--neon-font-weight-semi-bold);
         }
 
         .neon-date-picker__calendar-date--selected:not(:disabled) {
@@ -171,7 +171,7 @@
           &.neon-date-picker__calendar-date--selected:hover {
             color: var(--neon-color-inverse);
             background-color: var(--neon-color-#{$color});
-            font-weight: var(--neon-font-weight-bold);
+            font-weight: var(--neon-font-weight-semi-bold);
           }
         }
 
@@ -182,7 +182,7 @@
           &.neon-date-picker__calendar-option--selected:hover {
             color: var(--neon-color-inverse);
             background-color: var(--neon-color-#{$color});
-            font-weight: var(--neon-font-weight-bold);
+            font-weight: var(--neon-font-weight-semi-bold);
           }
         }
 
@@ -202,7 +202,7 @@
           &:active {
             color: var(--neon-color-#{$color});
             background-color: rgba(var(--neon-rgb-#{$color}), 0.25);
-            font-weight: var(--neon-font-weight-bold);
+            font-weight: var(--neon-font-weight-semi-bold);
           }
         }
 

--- a/src/sass/components/_dropdown-menu.scss
+++ b/src/sass/components/_dropdown-menu.scss
@@ -54,7 +54,7 @@
 
       .neon-link {
         text-decoration: none;
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
 
       .neon-link,
@@ -81,7 +81,7 @@
 
       &--group-title {
         .neon-dropdown-menu__item-container {
-          font-weight: var(--neon-font-weight-semi-bold);
+          font-weight: var(--neon-font-weight-medium);
           letter-spacing: var(--neon-letter-spacing-s);
           cursor: default;
 

--- a/src/sass/components/_expansion-panel.scss
+++ b/src/sass/components/_expansion-panel.scss
@@ -28,7 +28,7 @@
       align-items: center;
       cursor: pointer;
       letter-spacing: var(--neon-letter-spacing-s);
-      font-weight: var(--neon-font-weight-light);
+      font-weight: var(--neon-font-weight-extra-light);
       @include layout.padding-horizontal(0.75, 0.75);
       padding-top: 0;
       padding-bottom: 0;
@@ -148,7 +148,7 @@
     }
 
     .neon-expansion-indicator {
-      margin-right: -3rem;
+      margin-right: -2rem;
     }
 
     &--full-width {

--- a/src/sass/components/_filter-list.scss
+++ b/src/sass/components/_filter-list.scss
@@ -38,14 +38,14 @@
               }
             }
           } @else {
-            color: rgba(var(--neon-rgb-text), 0.75);
+            color: rgba(var(--neon-rgb-text-secondary), 0.75);
 
             &:hover,
             &:focus {
-              color: var(--neon-color-text);
+              color: var(--neon-color-text-secondary);
 
               &:after {
-                background-color: var(--neon-color-text);
+                background-color: var(--neon-color-text-secondary);
               }
             }
           }
@@ -65,7 +65,7 @@
         min-width: fit-content;
         margin-right: var(--neon-space-24);
         font-size: var(--neon-font-size-xs);
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
         font-variant: tabular-nums;
         line-height: 1;
       }
@@ -77,12 +77,12 @@
       }
 
       &:not(.neon-filter-list__item--disabled) {
-        color: rgba(var(--neon-rgb-text), 0.75);
+        color: rgba(var(--neon-rgb-text-secondary), 0.75);
 
         &.neon-filter-list__item--selected,
         &.neon-filter-list__item:hover,
         &.neon-filter-list__item:focus {
-          color: var(--neon-color-text);
+          color: var(--neon-color-text-secondary);
         }
 
         &.neon-filter-list__item:hover,

--- a/src/sass/components/_icon.scss
+++ b/src/sass/components/_icon.scss
@@ -13,7 +13,7 @@
 
   @each $neon-icon-type in $neon-icon-types {
     .#{$neon-icon-type} {
-      @include svg.svg-colors(var(--neon-color-text));
+      @include svg.svg-colors(var(--neon-color-text-secondary));
 
       @each $color in palettes.$neon-functional-colors {
         &--#{$color}:not(.#{$neon-icon-type}--disabled):not(.#{$neon-icon-type}--inverse) {

--- a/src/sass/components/_input.scss
+++ b/src/sass/components/_input.scss
@@ -130,7 +130,7 @@
       font-family: var(--neon-font-family-body);
       width: 100%;
       border-color: var(--neon-border-color-input);
-      color: var(--neon-color-text);
+      olor: var(--neon-color-text-secondary);
       background-color: var(--neon-background-color-input);
       box-shadow: var(--neon-inset-shadow);
 
@@ -153,7 +153,7 @@
 
     &:not(.neon-input--placeholder-visible) {
       input[type='password'] {
-        font-weight: bold;
+        font-weight: var(--neon-font-weight-semi-bold);
         letter-spacing: calc(2 * var(--neon-letter-spacing-m));
       }
     }

--- a/src/sass/components/_label.scss
+++ b/src/sass/components/_label.scss
@@ -77,7 +77,7 @@
     user-select: none;
     min-width: fit-content;
     width: fit-content;
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
 
     &__label {
       white-space: nowrap;

--- a/src/sass/components/_linear-progress.scss
+++ b/src/sass/components/_linear-progress.scss
@@ -89,7 +89,7 @@
 
     &__output {
       margin-left: var(--neon-space-8);
-      font-weight: var(--neon-font-weight-bold);
+      font-weight: var(--neon-font-weight-semi-bold);
       font-variant: tabular-nums;
     }
   }

--- a/src/sass/components/_list.scss
+++ b/src/sass/components/_list.scss
@@ -14,7 +14,7 @@
           @if (not($color == 'low-contrast' or $color == 'neutral')) {
             @include svg.color-with-svg(rgba($list-foreground-rgb, 0.75));
           } @else {
-            @include svg.color-with-svg(rgba(var(--neon-rgb-text), 0.75));
+            @include svg.color-with-svg(rgba(var(--neon-rgb-text-secondary), 0.75));
           }
 
           &:hover,
@@ -23,7 +23,7 @@
             @if (not($color == 'low-contrast' or $color == 'neutral')) {
               @include svg.color-with-svg(rgba($list-foreground-rgb));
             } @else {
-              @include svg.color-with-svg(var(--neon-color-text));
+              @include svg.color-with-svg(var(--neon-color-text-secondary));
             }
           }
         }

--- a/src/sass/components/_menu.scss
+++ b/src/sass/components/_menu.scss
@@ -78,7 +78,7 @@
 
             & > .neon-link:not(.router-link-active),
             .neon-button:not(.router-link-active) {
-              @include svg.color-with-svg(var(--neon-color-text));
+              @include svg.color-with-svg(var(--neon-color-text-secondary));
             }
           }
         }

--- a/src/sass/components/_note.scss
+++ b/src/sass/components/_note.scss
@@ -43,7 +43,7 @@
 
         .neon-note__title {
           @if ($color == low-contrast or $color == high-contrast or $color == neutral) {
-            color: var(--neon-color-text-strong);
+            color: var(--neon-color-text-primary);
           } @else {
             color: var(--neon-color-#{$color});
           }

--- a/src/sass/components/_notification-counter.scss
+++ b/src/sass/components/_notification-counter.scss
@@ -15,13 +15,13 @@
     top: -10rem;
     right: -10rem;
     user-select: none;
-    font-weight: var(--neon-font-weight-semi-bold);
+    font-weight: var(--neon-font-weight-medium);
 
     @each $color in palettes.$neon-functional-colors {
       &--#{$color} {
         color: var(--neon-color-inverse);
         @if ($color == high-contrast) {
-          background-color: var(--neon-color-text);
+          background-color: var(--neon-color-text-secondary);
         } @else {
           background-color: var(--neon-color-#{$color});
         }

--- a/src/sass/components/_number.scss
+++ b/src/sass/components/_number.scss
@@ -32,7 +32,7 @@
           @if (not index(palettes.$neon-neutral-colors, $color)) {
             @include svg.color-with-svg(rgb($number-component-rgb));
           } @else {
-            @include svg.color-with-svg(var(--neon-color-text));
+            @include svg.color-with-svg(var(--neon-color-text-secondary));
           }
 
           &:hover,
@@ -43,7 +43,7 @@
             @if (not index(palettes.$neon-neutral-colors, $color)) {
               @include svg.color-with-svg(rgb($number-component-rgb));
             } @else {
-              @include svg.color-with-svg(var(--neon-color-text));
+              @include svg.color-with-svg(var(--neon-color-text-secondary));
             }
           }
         }

--- a/src/sass/components/_range-slider.scss
+++ b/src/sass/components/_range-slider.scss
@@ -102,7 +102,7 @@
     &.neon-range-slider__output-range-separator {
       margin-left: var(--neon-space-6);
       margin-right: var(--neon-space-6);
-      font-weight: var(--neon-font-weight-bold);
+      font-weight: var(--neon-font-weight-semi-bold);
       opacity: 0.25;
       top: -1rem;
       position: relative;

--- a/src/sass/components/_search.scss
+++ b/src/sass/components/_search.scss
@@ -172,7 +172,7 @@
       }
 
       .neon-link {
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
 
       &-container {
@@ -191,7 +191,7 @@
         flex: 1 0 auto;
         user-select: none;
         align-items: center;
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
         font-size: var(--neon-font-size-xs);
         text-transform: uppercase;
         padding: var(--neon-space-12) var(--neon-space-16) var(--neon-space-4);

--- a/src/sass/components/_select.scss
+++ b/src/sass/components/_select.scss
@@ -54,7 +54,7 @@
       }
 
       .neon-link {
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
 
       &--disabled {
@@ -86,7 +86,7 @@
         flex: 1 0 auto;
         user-select: none;
         align-items: center;
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
         font-size: var(--neon-font-size-xs);
         text-transform: uppercase;
         padding: var(--neon-space-12) var(--neon-space-16) var(--neon-space-4);

--- a/src/sass/components/_slider.scss
+++ b/src/sass/components/_slider.scss
@@ -107,7 +107,7 @@ $neon-width-slider-tooltip: 201rem;
         font-size: var(--neon-font-size-s);
         font-variant: tabular-nums;
         line-height: 1;
-        font-weight: var(--neon-font-weight-bold);
+        font-weight: var(--neon-font-weight-semi-bold);
         letter-spacing: 0;
         padding: var(--neon-space-8);
         border-radius: var(--neon-border-radius-slider-tooltip);

--- a/src/sass/components/_stepper.scss
+++ b/src/sass/components/_stepper.scss
@@ -90,7 +90,7 @@
       &--active,
       &--has-value {
         .neon-stepper__step-title {
-          color: var(--neon-color-text-strong);
+          color: var(--neon-color-text-primary);
         }
       }
 
@@ -102,7 +102,7 @@
         }
 
         .neon-stepper__step-title {
-          font-weight: var(--neon-font-weight-bold);
+          font-weight: var(--neon-font-weight-semi-bold);
         }
       }
     }
@@ -118,7 +118,7 @@
 
         .neon-stepper__step--active, {
           .neon-stepper__step-title {
-            font-weight: var(--neon-font-weight-bold);
+            font-weight: var(--neon-font-weight-semi-bold);
             color: var(--neon-color-#{$color});
           }
         }

--- a/src/sass/components/_switch.scss
+++ b/src/sass/components/_switch.scss
@@ -59,7 +59,7 @@
     align-items: center;
     width: fit-content;
     cursor: pointer;
-    color: var(--neon-color-text);
+    color: var(--neon-color-text-secondary);
 
     &:focus {
       outline: none;

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -41,7 +41,7 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      font-weight: var(--neon-font-weight-semi-bold);
+      font-weight: var(--neon-font-weight-medium);
     }
 
     .neon-tabs__menu-item {
@@ -66,14 +66,14 @@
         outline: none;
         height: 100%;
         align-items: center;
-        color: var(--neon-color-text-strong);
+        color: var(--neon-color-text-primary);
 
         .neon-svg--stroke {
-          stroke: var(--neon-color-text-strong);
+          stroke: var(--neon-color-text-primary);
         }
 
         .neon-svg--fill {
-          fill: var(--neon-color-text-strong);
+          fill: var(--neon-color-text-primary);
         }
 
         &:before {
@@ -178,7 +178,7 @@
           width: 100%;
           padding-top: calc(3 * var(--neon-base-space));
           padding-bottom: calc(2 * var(--neon-base-space));
-          font-weight: var(--neon-font-weight-semi-bold);
+          font-weight: var(--neon-font-weight-medium);
           font-size: var(--neon-font-size-xs);
           line-height: 1.26;
 

--- a/src/sass/components/_toggle.scss
+++ b/src/sass/components/_toggle.scss
@@ -42,8 +42,8 @@
           $toggle-color: var(--neon-color-#{$color}) !default;
 
           @if ($color == high-contrast) {
-            $toggle-rgb: var(--neon-rgb-text);
-            $toggle-color: var(--neon-color-text);
+            $toggle-rgb: var(--neon-rgb-text-secondary);
+            $toggle-color: var(--neon-color-text-secondary);
           }
 
           @include svg.color-with-svg(rgba($toggle-rgb, var(--neon-opacity-toggle-color)));
@@ -103,7 +103,7 @@
             }
 
             &.neon-toggle__label--checked {
-              color: var(--neon-color-text);
+              color: var(--neon-color-text-secondary);
 
               .neon-toggle__radio-button {
                 border: var(--neon-border-width-radio-button) var(--neon-border-style) var(--neon-color-#{$color});

--- a/src/sass/components/_tooltip.scss
+++ b/src/sass/components/_tooltip.scss
@@ -65,8 +65,8 @@
       font-size: var(--neon-font-size-xs);
       text-transform: none;
       line-height: var(--neon-line-height-ratio);
-      font-weight: var(--neon-font-weight-semi-bold);
-      background: var(--neon-color-text);
+      font-weight: var(--neon-font-weight-medium);
+      background: var(--neon-color-text-secondary);
       color: var(--neon-color-inverse);
       border: var(--neon-border-width-tooltip) solid var(--neon-border-color);
       box-shadow: var(--neon-box-shadow-tooltip);
@@ -97,7 +97,7 @@
       .neon-tooltip__arrow {
         top: calc(100% + var(--neon-space-4));
         margin-top: -6rem;
-        border-top: 6rem solid var(--neon-color-text);
+        border-top: 6rem solid var(--neon-color-text-secondary);
         z-index: var(--neon-z-index-above-2);
       }
     }
@@ -110,7 +110,7 @@
       .neon-tooltip__arrow {
         bottom: calc(100% + var(--neon-space-4));
         margin-bottom: -6rem;
-        border-bottom: 6rem solid var(--neon-color-text);
+        border-bottom: 6rem solid var(--neon-color-text-secondary);
         z-index: var(--neon-z-index-above-2);
       }
     }
@@ -144,7 +144,7 @@
       .neon-tooltip__arrow {
         left: calc(100% + var(--neon-space-4));
         margin-left: -6rem;
-        border-left: 6rem solid var(--neon-color-text);
+        border-left: 6rem solid var(--neon-color-text-secondary);
         z-index: var(--neon-z-index-above-2);
       }
     }
@@ -161,7 +161,7 @@
       .neon-tooltip__arrow {
         right: calc(100% + var(--neon-space-4));
         margin-right: -6rem;
-        border-right: 6rem solid var(--neon-color-text);
+        border-right: 6rem solid var(--neon-color-text-secondary);
         z-index: var(--neon-z-index-above-2);
       }
     }
@@ -199,7 +199,7 @@
           line-height: var(--neon-line-height-ratio);
           font-weight: var(--neon-font-weight-normal);
           background: var(--neon-color-inverse);
-          color: var(--neon-color-text);
+          color: var(--neon-color-text-secondary);
         }
 
         &__content-wrapper {

--- a/src/sass/components/_tree-menu.scss
+++ b/src/sass/components/_tree-menu.scss
@@ -24,7 +24,7 @@
         &,
         &:hover,
         &:active {
-          color: var(--neon-color-text);
+          color: var(--neon-color-text-secondary);
         }
 
         &.neon-link--exact-active {
@@ -53,15 +53,15 @@
 
     .neon-tree-menu__section-link {
       font-size: var(--neon-font-size-l);
-      font-weight: var(--neon-font-weight-bold);
+      font-weight: var(--neon-font-weight-semi-bold);
 
       &:visited {
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
     }
 
     .neon-tree-menu__section {
-      color: var(--neon-color-text);
+      color: var(--neon-color-text-secondary);
 
       & > .neon-tree-menu__link {
         font-size: var(--neon-font-size-m);
@@ -90,7 +90,7 @@
         font-weight: var(--neon-font-weight-normal);
         font-size: var(--neon-font-size-s);
         margin-bottom: var(--neon-space-2);
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
 
       .neon-tree-menu__anchor {
@@ -98,7 +98,7 @@
         margin-bottom: var(--neon-space-2);
         padding-left: var(--neon-space-16);
         font-size: var(--neon-font-size-s);
-        color: var(--neon-color-text);
+        color: var(--neon-color-text-secondary);
       }
     }
 

--- a/src/sass/global/_base-html.scss
+++ b/src/sass/global/_base-html.scss
@@ -9,7 +9,7 @@
   body {
     text-rendering: optimizeLegibility;
     background-color: var(--neon-background-color);
-    color: var(--neon-color-text);
+    color: var(--neon-color-text-secondary);
   }
 
 
@@ -106,7 +106,7 @@
   }
 
   pre.neon--preformatted {
-    color: var(--neon-color-text-light);
+    color: var(--neon-color-text-secondary-dark);
     background-color: var(--neon-background-color-pre);
 
     &:not(.prism-editor__editor) {
@@ -155,8 +155,16 @@
     }
   }
 
-  .neon-color-text {
-    color: var(--neon-color-text);
+  .neon-color-text-primary {
+    color: var(--neon-color-text-primary);
+  }
+
+  .neon-color-text-secondary {
+    color: var(--neon-color-text-secondary);
+  }
+
+  .neon-color-text-tertiary {
+    color: var(--neon-color-text-tertiary);
   }
 
   .neon-color-inverse {
@@ -164,46 +172,46 @@
   }
 
   .neon-dark-text {
-    color: var(--neon-color-text-dark);
+    color: var(--neon-color-text-secondary-light);
   }
 
   .neon-light-text {
-    color: var(--neon-color-text-light);
+    color: var(--neon-color-text-secondary-dark);
   }
 
-  .neon-color-text-low-contrast {
+  .neon-color-low-contrast {
     color: var(--neon-color-low-contrast);
   }
 
-  .neon-color-text-neutral {
+  .neon-color-neutral {
     color: var(--neon-color-neutral);
   }
 
-  .neon-color-text-high-contrast {
+  .neon-color-high-contrast {
     color: var(--neon-color-high-contrast);
   }
 
-  .neon-color-text-brand {
+  .neon-color-brand {
     color: var(--neon-color-brand);
   }
 
-  .neon-color-text-primary {
+  .neon-color-primary {
     color: var(--neon-color-primary);
   }
 
-  .neon-color-text-info {
+  .neon-color-info {
     color: var(--neon-color-info);
   }
 
-  .neon-color-text-success {
+  .neon-color-success {
     color: var(--neon-color-success);
   }
 
-  .neon-color-text-warn {
+  .neon-color-warn {
     color: var(--neon-color-warn);
   }
 
-  .neon-color-text-error {
+  .neon-color-error {
     color: var(--neon-color-error);
   }
 }

--- a/src/sass/global/_table.scss
+++ b/src/sass/global/_table.scss
@@ -2,7 +2,7 @@
   table {
     border-spacing: 0;
     border-collapse: collapse;
-    border-bottom: var(--neon-border-width-table) var(--neon-border-style) var(--neon-label-color);
+    border-bottom: var(--neon-border-width-table) var(--neon-border-style) var(--neon-color-label);
 
     thead {
       tr {
@@ -10,13 +10,13 @@
           height: var(--neon-size-m);
           vertical-align: bottom;
           font-size: var(--neon-font-size-s);
-          font-weight: var(--neon-font-weight-semi-bold);
+          font-weight: var(--neon-font-weight-medium);
           text-transform: uppercase;
           text-align: left;
           padding: 0 var(--neon-space-24) 0 0;
           letter-spacing: var(--neon-letter-spacing-m);
-          border-bottom: var(--neon-border-width-table) var(--neon-border-style) var(--neon-label-color);
-          color: var(--neon-label-color);
+          border-bottom: var(--neon-border-width-table) var(--neon-border-style) var(--neon-color-label);
+          color: var(--neon-color-label);
 
           &.neon--number {
             text-align: right;

--- a/src/sass/global/_typography.scss
+++ b/src/sass/global/_typography.scss
@@ -18,6 +18,7 @@
 
   em {
     font-weight: var(--neon-font-weight-em);
+    margin-right: 1rem; // to account for the slanting text
   }
 
   strong {
@@ -140,6 +141,6 @@
   h6,
   .neon-h6,
   .neon-color-heading {
-    color: var(--neon-color-heading);
+    color: var(--neon-color-text-primary);
   }
 }

--- a/src/sass/includes/_outline.scss
+++ b/src/sass/includes/_outline.scss
@@ -9,7 +9,7 @@
 
     &:after {
       content: '';
-      font-weight: bold;
+      font-weight: var(--neon-font-weight-semi-bold);
       position: absolute;
       left: 0;
       bottom: var(--neon-border-bottom-offset-link);

--- a/src/sass/includes/_typography.scss
+++ b/src/sass/includes/_typography.scss
@@ -48,7 +48,7 @@
 }
 
 @mixin label {
-  color: var(--neon-label-color);
+  color: var(--neon-color-label);
   font-size: var(--neon-font-size-xs);
   font-weight: var(--neon-font-weight-semi-bold);
   letter-spacing: var(--neon-letter-spacing-s);

--- a/src/sass/palette.scss
+++ b/src/sass/palette.scss
@@ -3,15 +3,12 @@
   This is why there are 2 color definitions the raw 'rgb' definition and the actual 'color' one
 */
 .neon {
-  // TODO: rename to primary & secondary text
-  --neon-rgb-text-dark: 48, 48, 48;
-  --neon-rgb-text-strong-dark: 36, 36, 36;
-  --neon-rgb-text-light: 221, 221, 221;
-  --neon-rgb-text-strong-light: 248, 248, 248;
-  // tertiary text values
-  --neon-rgb-text-tertiary-dark: 114, 114, 114;
-  --neon-rgb-text-tertiary-light: 144, 144, 144;
-
+  --neon-rgb-text-primary-light: 20, 20, 20;
+  --neon-rgb-text-secondary-light: 51, 51, 51;
+  --neon-rgb-text-tertiary-light: 114, 114, 114;
+  --neon-rgb-text-primary-dark: 248, 248, 248;
+  --neon-rgb-text-secondary-dark: 221, 221, 221;
+  --neon-rgb-text-tertiary-dark: 166, 166, 166;
   --neon-rgb-disabled-background-dark: 55, 55, 55;
   --neon-rgb-disabled-border-dark: 65, 65, 65;
   --neon-rgb-disabled-text-dark: 80, 80, 80;

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -115,27 +115,28 @@
   /* AKA branding font size, used for landing page & banners etc... */
   --neon-h0-size: calc(var(--neon-font-size-xxl) * var(--neon-typography-scale) * var(--neon-typography-scale) * var(--neon-typography-scale) * var(--neon-typography-scale) * var(--neon-typography-scale));
 
-  --neon-font-weight-lighter: 200;
+  --neon-font-weight-extra-light: 200;
   --neon-font-weight-normal: 400;
-  --neon-font-weight-semi-bold: 500;
-  --neon-font-weight-bold: 600;
+  --neon-font-weight-medium: 500;
+  --neon-font-weight-semi-bold: 600;
+  --neon-font-weight-bold: 700;
 
   --neon-h6-weight: var(--neon-font-weight-normal);
-  --neon-h5-weight: var(--neon-font-weight-normal);
-  --neon-h4-weight: var(--neon-font-weight-normal);
+  --neon-h5-weight: var(--neon-font-weight-medium);
+  --neon-h4-weight: var(--neon-font-weight-medium);
   --neon-h3-weight: var(--neon-font-weight-semi-bold);
   --neon-h2-weight: var(--neon-font-weight-semi-bold);
   --neon-h1-weight: var(--neon-font-weight-bold);
   --neon-h0-weight: var(--neon-font-weight-bold);
 
-  --neon-font-weight-em: var(--neon-font-weight-lighter);
-  --neon-font-weight-strong: var(--neon-font-weight-bold);
+  --neon-font-weight-em: var(--neon-font-weight-extra-light);
+  --neon-font-weight-strong: var(--neon-font-weight-medium);
 
   --neon-letter-spacing-headings: 0;
 
-  --neon-line-height-headings-ratio: 1.2;
+  --neon-line-height-headings-ratio: 1.25;
   --neon-line-height-ratio: 1.4;
-  --neon-line-height-one: 1.125; // hack for line-height: 1 to prevent cropping of content below the baseline e.g. 'g'
+  --neon-line-height-one: 1.25; // hack for line-height: 1 to prevent cropping of content below the baseline e.g. 'g'
 
   --neon-system-font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
   'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
@@ -218,7 +219,7 @@
   --neon-opacity-chip: 0.23;
 
   /* toggle chips */
-  --neon-font-weight-toggle-chip: var(--neon-font-weight-bold);
+  --neon-font-weight-toggle-chip: var(--neon-font-weight-semi-bold);
   --neon-border-width-toggle-chip: 1rem;
   --neon-border-radius-toggle-chip: 2rem;
   --neon-opacity-toggle-chip-hover: 0.125;
@@ -256,8 +257,8 @@
   --neon-font-size-note-text: var(--neon-font-size-s);
   --neon-font-size-note-text-mobile: var(--neon-font-size-m);
 
-  --neon-font-weight-note-title: var(--neon-font-weight-bold);
-  --neon-font-weight-note-text: var(--neon-font-weight-semi-bold);
+  --neon-font-weight-note-title: var(--neon-font-weight-semi-bold);
+  --neon-font-weight-note-text: var(--neon-font-weight-medium);
 
   --neon-max-width-note: 100%;
 
@@ -323,21 +324,14 @@
     --neon-border-card: var(--neon-border);
     --neon-background-color: var(--neon-color-neutral-d5);
 
-    --neon-rgb-text: var(--neon-rgb-text-light);
-    --neon-color-text: var(--neon-color-text-light);
-    --neon-rgb-text-strong: var(--neon-rgb-text-strong-light);
-    --neon-color-text-strong: var(--neon-color-text-strong-light);
-
-    // alias to new variables
-    --neon-rgb-text-primary: var(--neon-rgb-text-strong);
-    --neon-color-text-primary: var(--neon-color-text-strong);
-    --neon-rgb-text-secondary: var(--neon-rgb-text);
-    --neon-color-text-secondary: var(--neon-color-text);
-    --neon-rgb-text-tertiary: var(--neon-rgb-text-tertiary-light);
-    --neon-color-text-tertiary: rgb(var(--neon-rgb-text-tertiary));
-
-    --neon-rgb-inverse: var(--neon-rgb-text-strong-dark);
-    --neon-color-inverse: var(--neon-color-text-strong-dark);
+    --neon-rgb-text-primary: var(--neon-rgb-text-primary-dark);
+    --neon-color-text-primary: var(--neon-color-text-primary-dark);
+    --neon-rgb-text-secondary: var(--neon-rgb-text-secondary-dark);
+    --neon-color-text-secondary: var(--neon-color-text-secondary-dark);
+    --neon-rgb-text-tertiary: var(--neon-rgb-text-tertiary-dark);
+    --neon-color-text-tertiary: var(--neon-color-text-tertiary-dark);
+    --neon-rgb-inverse: var(--neon-rgb-text-primary-light);
+    --neon-color-inverse: var(--neon-color-text-primary-light);
 
     --neon-rgb-low-contrast: var(--neon-rgb-low-contrast-l1);
     --neon-rgb-neutral: var(--neon-rgb-neutral-l1);
@@ -375,7 +369,7 @@
     --neon-border-hr: 1rem var(--neon-border-style) var(--neon-border-color);
     --neon-color-hr: var(--neon-border-color);
 
-    --neon-label-color: var(--neon-color-neutral-l1);
+    --neon-color-label: var(--neon-color-text-secondary);
 
     --neon-rgb-disabled-text: var(--neon-rgb-disabled-text-dark);
     --neon-rgb-disabled-border: var(--neon-rgb-disabled-border-dark);
@@ -393,11 +387,11 @@
 
     /* solid buttons */
     --neon-color-solid-button: var(--neon-color-inverse);
-    --neon-color-solid-button-inverse: var(--neon-color-text-strong);
+    --neon-color-solid-button-inverse: var(--neon-color-text-primary);
 
-    --neon-background-solid-button-light-high-contrast: var(--neon-color-text-strong);
-    --neon-background-rgb-solid-button-dark-high-contrast: var(--neon-rgb-text-strong);
-    --neon-background-solid-button-dark-high-contrast: var(--neon-color-text-strong);
+    --neon-background-solid-button-light-high-contrast: var(--neon-color-text-primary);
+    --neon-background-rgb-solid-button-dark-high-contrast: var(--neon-rgb-text-primary);
+    --neon-background-solid-button-dark-high-contrast: var(--neon-color-text-primary);
 
     --neon-background-solid-button-light-inverse: var(--neon-color-inverse);
     --neon-background-rgb-solid-button-dark-inverse: var(--neon-rgb-inverse);
@@ -473,7 +467,7 @@
 
     /* note */
     --neon-background-color-note: rgba(var(--neon-rgb-high-contrast-d3), 0.5);
-    --neon-color-note: var(--neon-color-text);
+    --neon-color-note: var(--neon-color-text-secondary);
 
     /* link */
     --neon-color-link: var(--neon-color-primary-l1);
@@ -629,21 +623,14 @@
     --neon-border-card: var(--neon-border);
     --neon-background-color: var(--neon-color-high-contrast-l4);
 
-    --neon-rgb-text: var(--neon-rgb-text-dark);
-    --neon-color-text: var(--neon-color-text-dark);
-    --neon-rgb-text-strong: var(--neon-rgb-text-strong-dark);
-    --neon-color-text-strong: var(--neon-color-text-strong-dark);
-
-    // alias to new variables
-    --neon-rgb-text-primary: var(--neon-rgb-text-strong);
-    --neon-color-text-primary: var(--neon-color-text-strong);
-    --neon-rgb-text-secondary: var(--neon-rgb-text);
-    --neon-color-text-secondary: var(--neon-color-text);
-    --neon-rgb-text-tertiary: var(--neon-rgb-text-tertiary-dark);
-    --neon-color-text-tertiary: rgb(var(--neon-rgb-text-tertiary));
-
-    --neon-rgb-inverse: var(--neon-rgb-text-strong-light);
-    --neon-color-inverse: var(--neon-color-text-strong-light);
+    --neon-rgb-text-primary: var(--neon-rgb-text-primary-light);
+    --neon-color-text-primary: var(--neon-color-text-primary-light);
+    --neon-rgb-text-secondary: var(--neon-rgb-text-secondary-light);
+    --neon-color-text-secondary: var(--neon-color-text-secondary-light);
+    --neon-rgb-text-tertiary: var(--neon-rgb-text-tertiary-light);
+    --neon-color-text-tertiary: var(--neon-color-text-tertiary-light);
+    --neon-rgb-inverse: var(--neon-rgb-text-primary-dark);
+    --neon-color-inverse: var(--neon-color-text-primary-dark);
 
     --neon-rgb-low-contrast: var(--neon-rgb-low-contrast-d1);
     --neon-rgb-neutral: var(--neon-rgb-neutral-d1);
@@ -681,7 +668,7 @@
     --neon-border-hr: 1rem var(--neon-border-style) var(--neon-border-color);
     --neon-color-hr: var(--neon-border-color);
 
-    --neon-label-color: var(--neon-color-neutral-d1);
+    --neon-color-label: var(--neon-color-text-secondary);
 
     --neon-rgb-disabled-text: var(--neon-rgb-disabled-text-light);
     --neon-rgb-disabled-border: var(--neon-rgb-disabled-border-light);
@@ -699,11 +686,11 @@
 
     /* solid buttons */
     --neon-color-solid-button: var(--neon-color-inverse);
-    --neon-color-solid-button-inverse: var(--neon-color-text-strong);
+    --neon-color-solid-button-inverse: var(--neon-color-text-primary);
 
-    --neon-background-solid-button-light-high-contrast: var(--neon-color-text);
-    --neon-background-rgb-solid-button-dark-high-contrast: var(--neon-rgb-text);
-    --neon-background-solid-button-dark-high-contrast: var(--neon-color-text);
+    --neon-background-solid-button-light-high-contrast: var(--neon-color-text-secondary);
+    --neon-background-rgb-solid-button-dark-high-contrast: var(--neon-rgb-text-secondary);
+    --neon-background-solid-button-dark-high-contrast: var(--neon-color-text-secondary);
 
     --neon-background-solid-button-light-inverse: var(--neon-color-inverse);
     --neon-background-rgb-solid-button-dark-inverse: var(--neon-rgb-inverse);
@@ -779,7 +766,7 @@
 
     /* note */
     --neon-background-color-note: rgba(var(--neon-rgb-high-contrast-l3), 0.5);
-    --neon-color-note: var(--neon-color-text);
+    --neon-color-note: var(--neon-color-text-secondary);
 
     /* link */
     --neon-color-link: var(--neon-color-primary-d1);
@@ -822,7 +809,7 @@
 
     /* drop zone */
     --neon-rgb-drop-zone-background: var(--neon-rgb-high-contrast-l4);
-    --neon-rgb-drop-zone: var(--neon-rgb-text);
+    --neon-rgb-drop-zone: var(--neon-rgb-text-secondary);
 
     /* alerts */
     --neon-box-shadow-alert: calc(0.5 * var(--neon-base-space)) calc(0.5 * var(--neon-base-space)) calc(2 * var(--neon-base-space)) rgba(var(--neon-rgb-neutral-d1), 0.5);


### PR DESCRIPTION
## Describe your changes
- correct naming of font weights
- adjust text color variables to add tertiary text & reduce confusion around text variable names
- update palette creator to include tertiary text, bugfixing
- bugfix: adjust showcase to use correct button colors after default color change
- minor bugfixing

BREAKING:
- removed `--neon-color-text` & `--neon-color-text-strong` CSS variables. Use `--neon-color-text-primary`, `--neon-color-text-secondary` & `--neon-color-text-tertiary` instead.
- renamed `.neon-color-text-<color>` classes to `.neon-color-<color>`
