### PR TITLE
refactor!: centered NeonPage option

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -87,9 +87,7 @@
     }
 
     .app-footer {
-      max-width: calc(var(--neon-max-page-width) - var(--neon-side-nav-width));
-
-      .neon-footer__container {
+      &__contents {
         align-items: center;
       }
     }

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app" class="neon-app neon-app--standard-page">
-    <neon-page>
+    <neon-page page-align="left">
       <template v-if="isTablet" #top-nav>
         <neon-top-nav class="app-top-nav">
           <span class="logo-wrapper top-nav-logo-wrapper">
@@ -123,11 +123,15 @@
             </router-view>
           </neon-grid-area>
         </neon-grid>
+      </template>
+      <template #footer>
         <neon-footer class="app-footer">
-          <span>
-            {{ versionString !== '0' ? versionString : '' }} &copy; copyright aotearoan
-            {{ new Date().getFullYear() }}
-          </span>
+          <div class="app-footer__contents">
+            <span>
+              {{ versionString !== '0' ? versionString : '' }} &copy; copyright aotearoan
+              {{ new Date().getFullYear() }}
+            </span>
+          </div>
         </neon-footer>
       </template>
     </neon-page>

--- a/src/app/components/component-documentation/ComponentDocumentation.scss
+++ b/src/app/components/component-documentation/ComponentDocumentation.scss
@@ -7,18 +7,18 @@ $neon-height-component-header-mobile: 77rem;
 $fixed-content-height: 348rem;
 
 .component-documentation {
-  margin-top: calc(#{$neon-height-component-header-desktop} - 0.5 * var(--neon-spacing-vertical-desktop));
+  margin-top: calc(#{$neon-height-component-header-desktop} - 0.5 * var(--neon-gutter-desktop));
 
   &__description-heading {
     display: none;
   }
 
   @include responsive.responsive(tablet) {
-    margin-top: calc(#{$neon-height-component-header-desktop} - var(--neon-spacing-vertical-tablet));
+    margin-top: calc(#{$neon-height-component-header-desktop} - var(--neon-gutter-tablet));
   }
 
   @include responsive.responsive(mobile-large) {
-    margin-top: calc(#{$neon-height-component-header-mobile} - 0.5 * var(--neon-spacing-vertical-mobile));
+    margin-top: calc(#{$neon-height-component-header-mobile} - 0.5 * var(--neon-gutter-mobile));
 
     &__description-heading {
       display: flex;
@@ -34,7 +34,7 @@ $fixed-content-height: 348rem;
     z-index: var(--neon-z-index-above-2);
     @include layout.padding(1, true);
     padding-bottom: 0 !important;
-    max-width: calc(var(--neon-max-page-width) - var(--neon-side-nav-width));
+    max-width: calc(var(--neon-max-width-page) - var(--neon-side-nav-width));
     top: 0;
     left: var(--neon-side-nav-width);
     width: calc(100vw - var(--neon-side-nav-width));

--- a/src/app/components/editor/Editor.scss
+++ b/src/app/components/editor/Editor.scss
@@ -12,8 +12,8 @@
     font-variation-settings: var(--monospaced-font-variation-settings);
     font-size: var(--neon-font-size-m);
     line-height: var(--neon-line-height-ratio);
-    min-width: 100%;
-    width: var(--neon-max-paragraph-width);
+    width: 100%;
+    max-width: var(--neon-max-paragraph-width);
     height: 100%;
     overflow: visible;
 

--- a/src/app/views/design/layout/Layout.scss
+++ b/src/app/views/design/layout/Layout.scss
@@ -19,6 +19,11 @@
     flex-direction: row;
   }
 
+  .layout-example__with-footer {
+    flex-direction: column;
+    width: 100%;
+  }
+
   .layout-example__side-nav {
     width: 25%;
 
@@ -29,6 +34,5 @@
 
   .layout-example__grid-wrapper {
     flex: 1 1 auto;
-    width: 75%;
   }
 }

--- a/src/app/views/design/layout/Layout.vue
+++ b/src/app/views/design/layout/Layout.vue
@@ -54,28 +54,32 @@
                     <span class="layout-example__label">#scrolling</span>
                   </div>
                 </div>
-                <div class="layout-example layout-example__grid-wrapper">
-                  <span class="layout-example__label">#content</span>
-                  <div class="layout-example">
-                    <neon-link class="layout-example__label" href="/layout/grid">NeonGrid</neon-link>
+                <div class="layout-example__with-footer">
+                  <div class="layout-example layout-example__grid-wrapper">
+                    <span class="layout-example__label">#content</span>
                     <div class="layout-example">
-                      <span class="layout-example__label"
-                        >Grid section 1 (<neon-link class="layout-example__link" href="/layout/grid#api"
-                          >NeonGridArea</neon-link
-                        >)</span
-                      >
-                    </div>
-                    <div class="layout-example__label">...</div>
-                    <div class="layout-example">
-                      <span class="layout-example__label"
-                        >Grid section n (<neon-link class="layout-example__link" href="/layout/grid#api"
-                          >NeonGridArea</neon-link
-                        >)</span
-                      >
+                      <neon-link class="layout-example__label" href="/layout/grid">NeonGrid</neon-link>
+                      <div class="layout-example">
+                        <span class="layout-example__label">
+                          Grid section 1 (<neon-link class="layout-example__link" href="/layout/grid#api"
+                            >NeonGridArea</neon-link
+                          >)
+                        </span>
+                      </div>
+                      <div class="layout-example__label">...</div>
+                      <div class="layout-example">
+                        <span class="layout-example__label">
+                          Grid section n (<neon-link class="layout-example__link" href="/layout/grid#api"
+                            >NeonGridArea</neon-link
+                          >)
+                        </span>
+                      </div>
                     </div>
                   </div>
-                  <div class="layout-example">
-                    <neon-link class="layout-example__label" href="/layout/footer">NeonFooter</neon-link>
+                  <div class="layout-example layout-example__grid-wrapper">
+                    <span class="layout-example__label">
+                      #footer (<neon-link class="layout-example__label" href="/layout/footer">NeonFooter</neon-link>)
+                    </span>
                   </div>
                 </div>
               </div>
@@ -124,10 +128,12 @@
                     >
                   </div>
                 </div>
-                <div class="layout-example">
-                  <neon-link class="layout-example__label" href="/layout/footer">NeonFooter</neon-link>
-                </div>
               </div>
+            </div>
+            <div class="layout-example">
+              <span class="layout-example__label">
+                #footer (<neon-link class="layout-example__link" href="/layout/footer">NeonFooter</neon-link>)
+              </span>
             </div>
           </div>
         </neon-stack>

--- a/src/app/views/layout/footer/Footer.vue
+++ b/src/app/views/layout/footer/Footer.vue
@@ -3,8 +3,9 @@
     <neon-card>
       <neon-card-body>
         <p>
-          The page footer component. Place directly inside the <strong>NeonPage</strong> component to have it rendered
-          at the bottom of the page even when the content is shorter than the page.
+          The page footer component. Place directly inside the <strong>NeonPage</strong> component
+          <strong>#footer</strong> slot to have it rendered at the bottom of the page even when the content is shorter
+          than the page.
         </p>
       </neon-card-body>
       <neon-card-body>

--- a/src/common/enums/NeonPageAlignment.ts
+++ b/src/common/enums/NeonPageAlignment.ts
@@ -1,0 +1,4 @@
+export enum NeonPageAlignment {
+  CENTER = 'center',
+  LEFT = 'left',
+}

--- a/src/common/utils/NeonModeUtils.ts
+++ b/src/common/utils/NeonModeUtils.ts
@@ -2,7 +2,7 @@ import { NeonMode } from '../enums/NeonMode';
 
 /**
  * Utility for managing Neon's light/dark mode & defaulting to the user's preference. See
- * <a href="https://neon.development.arcual.art/design/theming#dark-mode">Dark mode</a>.
+ * <a href="https://aotearoan.github.io/neon/design/theming#dark-mode">Dark mode</a>.
  */
 export class NeonModeUtils {
   private static defaultMode = NeonMode.Light;

--- a/src/components/layout/footer/NeonFooter.ts
+++ b/src/components/layout/footer/NeonFooter.ts
@@ -1,6 +1,7 @@
 import { defineComponent } from 'vue';
 
 /**
- * The page footer component. Place directly inside the NeonPage component to have it rendered at the bottom of the page even when the content is shorter than the page.
+ * The page footer component. Place directly inside the NeonPage component <strong>#footer</strong> slot to have it
+ * rendered at the bottom of the page even when the content is shorter than the page.
  */
 export default defineComponent({ name: 'NeonFooter' });

--- a/src/components/layout/page/NeonPage.ts
+++ b/src/components/layout/page/NeonPage.ts
@@ -1,4 +1,5 @@
 import { defineComponent, onMounted, onUnmounted } from 'vue';
+import { NeonPageAlignment } from '@/common/enums/NeonPageAlignment';
 
 /**
  * A "page" component, this is defined as a wrapper around the contents (NeonGrid, etc) and footer which provides the
@@ -6,6 +7,12 @@ import { defineComponent, onMounted, onUnmounted } from 'vue';
  */
 export default defineComponent({
   name: 'NeonPage',
+  props: {
+    /**
+     * Page alignment: either left aligned or center aligned.
+     */
+    pageAlign: { type: String as () => NeonPageAlignment, default: NeonPageAlignment.CENTER },
+  },
   setup(_props, { slots }) {
     const handleResize = () => {
       const vh = window.innerHeight * 0.01;

--- a/src/components/layout/page/NeonPage.vue
+++ b/src/components/layout/page/NeonPage.vue
@@ -1,6 +1,13 @@
 <template>
   <div
-    :class="{ 'neon-page--with-top-nav': slots['top-nav'], 'neon-page--with-side-nav': slots['side-nav'] }"
+    :class="[
+      {
+        'neon-page--with-top-nav': slots['top-nav'],
+        'neon-page--with-side-nav': slots['side-nav'],
+        'neon-page--with-footer': slots['footer'],
+      },
+      `neon-page--${pageAlign}`,
+    ]"
     class="neon-page"
   >
     <!-- @slot The <strong>NeonTopNav</strong> slot. This slot is required to ensure the correct responsive page layout. -->
@@ -11,6 +18,8 @@
       <!-- @slot The main page content -->
       <slot name="content"></slot>
     </div>
+    <!-- @slot The <strong>NeonFooter</strong> slot. This slot is required to ensure the correct responsive page layout. -->
+    <slot name="footer"></slot>
   </div>
 </template>
 

--- a/src/neon.ts
+++ b/src/neon.ts
@@ -82,6 +82,7 @@ export { NeonLabelSize } from './common/enums/NeonLabelSize';
 export { NeonMode } from './common/enums/NeonMode';
 export { NeonOrientation } from './common/enums/NeonOrientation';
 export { NeonOutlineStyle } from './common/enums/NeonOutlineStyle';
+export { NeonPageAlignment } from './common/enums/NeonPageAlignment';
 export { NeonPosition } from './common/enums/NeonPosition';
 export { NeonResponsive } from './common/enums/NeonResponsive';
 export { NeonSize } from './common/enums/NeonSize';

--- a/src/sass/components/_expansion-panel.scss
+++ b/src/sass/components/_expansion-panel.scss
@@ -55,14 +55,14 @@
 
     &__content {
       @include layout.padding-horizontal(0.75, 0.75);
-      padding-bottom: calc(0.75 * var(--neon-spacing-vertical-desktop));
+      padding-bottom: calc(0.75 * var(--neon-gutter-desktop));
 
       @include responsive.responsive(tablet) {
-        padding-bottom: calc(0.75 * var(--neon-spacing-vertical-tablet));
+        padding-bottom: calc(0.75 * var(--neon-gutter-tablet));
       }
 
       @include responsive.responsive(mobile-large) {
-        padding-bottom: calc(0.75 * var(--neon-spacing-vertical-mobile));
+        padding-bottom: calc(0.75 * var(--neon-gutter-mobile));
       }
     }
 

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -8,35 +8,37 @@
     background-color: var(--neon-background-color-footer);
     border-top: var(--neon-border-top-footer);
     color: var(--neon-color-neutral);
+    width: 100vw;
 
     &__container {
       display: flex;
       justify-content: center;
       width: 100%;
-      max-width: calc(var(--neon-max-page-width) + var(--neon-space-16));
+      max-width: calc(var(--neon-max-width-page) - 2 * var(--neon-gutter-desktop));
       line-height: var(--neon-line-height-one);
 
       @include responsive.responsive(larger-than-tablet) {
         font-size: var(--neon-font-size-m);
         height: var(--neon-footer-height-desktop);
-        padding: 0 var(--neon-spacing-vertical-desktop);
       }
 
       @include responsive.responsive(tablet) {
         font-size: var(--neon-font-size-s);
         height: var(--neon-footer-height-tablet);
-        padding: 0 var(--neon-spacing-vertical-tablet);
       }
 
       @include responsive.responsive(mobile-large) {
         font-size: var(--neon-font-size-s);
         height: var(--neon-footer-height-mobile);
-        padding: 0 var(--neon-spacing-vertical-mobile);
       }
     }
   }
 
   .neon-page--with-side-nav .neon-footer {
     @include layout.side-nav-offset;
+
+    .neon-footer__container {
+      max-width: calc(var(--neon-max-width-page) - var(--neon-side-nav-width) - 2 * var(--neon-gutter-desktop));
+    }
   }
 }

--- a/src/sass/components/_grid.scss
+++ b/src/sass/components/_grid.scss
@@ -3,20 +3,32 @@
 
 @mixin grid {
   .neon-grid {
-    width: 100vw;
-    max-width: var(--neon-max-page-width);
+    width: 100%;
+    max-width: 100%;
     @include layout.min-height(100, 'var(--neon-footer-height-desktop)');
-    @include layout.padding(0.5, true);
     display: grid;
 
+    @include responsive.responsive(larger-than-tablet) {
+      padding: var(--neon-gutter-desktop) 0;
+      gap: var(--neon-gutter-desktop);
+    }
+
+    @include responsive.responsive(tablet) {
+      padding: var(--neon-gutter-tablet) 0;
+      gap: var(--neon-gutter-tablet);
+    }
+
     @include responsive.responsive(mobile-large) {
+      padding: var(--neon-gutter-mobile) 0;
+      gap: var(--neon-gutter-mobile);
       display: flex;
       flex-direction: column;
     }
 
     .neon-grid-area {
-      @include layout.margin(0.5, true);
       display: flex;
+      width: 100%;
+      max-width: 100%;
 
       & > .neon-card {
         flex: 1 0 auto;
@@ -39,7 +51,6 @@
 
   .neon-page--with-side-nav .neon-grid {
     @include layout.side-nav-offset;
-    max-width: calc(var(--neon-max-page-width) - var(--neon-side-nav-width));
   }
 
   .neon-page--with-top-nav .neon-page__container {
@@ -54,30 +65,6 @@
 
       @include responsive.responsive(mobile-large) {
         @include layout.min-height(100, 'var(--neon-top-nav-height-mobile) + var(--neon-footer-height-mobile)');
-      }
-    }
-  }
-
-  .neon-grid {
-    .neon-grid-area {
-      @include responsive.responsive(larger-than-tablet) {
-        max-width: calc(100vw - 2 * var(--neon-spacing-vertical-desktop));
-      }
-
-      @include responsive.responsive(tablet) {
-        max-width: calc(100vw - 2 * var(--neon-spacing-vertical-tablet));
-      }
-
-      @include responsive.responsive(mobile-large) {
-        max-width: calc(100vw - 2 * var(--neon-spacing-vertical-mobile));
-      }
-    }
-  }
-
-  .neon-page--with-side-nav .neon-grid {
-    .neon-grid-area {
-      @include responsive.responsive(larger-than-tablet) {
-        max-width: calc(100vw - var(--neon-side-nav-width) + 2 * var(--neon-spacing-vertical-desktop));
       }
     }
   }

--- a/src/sass/components/_page.scss
+++ b/src/sass/components/_page.scss
@@ -23,5 +23,42 @@
         @include layout.min-height(100, 'var(--neon-top-nav-height-mobile)');
       }
     }
+
+    .neon-page__container {
+      @include responsive.responsive(larger-than-tablet) {
+        padding-left: var(--neon-gutter-desktop);
+        padding-right: var(--neon-gutter-desktop);
+        max-width: var(--neon-max-width-page);
+        width: 100%;
+      }
+
+      @include responsive.responsive(tablet) {
+        max-width: 100%;
+        width: 100%;
+        padding-left: var(--neon-gutter-tablet);
+        padding-right: var(--neon-gutter-tablet);
+      }
+
+      @include responsive.responsive(mobile-large) {
+        padding-left: var(--neon-gutter-mobile);
+        padding-right: var(--neon-gutter-mobile);
+      }
+    }
+
+    &--left {
+      &.neon-page--with-side-nav {
+        .neon-page__container {
+          @include responsive.responsive(larger-than-tablet) {
+            padding-left: 0;
+          }
+        }
+      }
+    }
+
+    &--center {
+      .neon-page__container {
+        margin: auto;
+      }
+    }
   }
 }

--- a/src/sass/components/_top-nav.scss
+++ b/src/sass/components/_top-nav.scss
@@ -13,12 +13,21 @@
     border-bottom: var(--neon-border-width) var(--neon-border-style) var(--neon-border-color-top-nav);
 
     &__container {
-      @include layout.padding-horizontal(1, 1);
-      // account for side nav
-      @include layout.spacing-horizontal('padding-left', larger-than-tablet, 0.75);
+      @include responsive.responsive(larger-than-tablet) {
+        padding: 0 var(--neon-gutter-desktop);
+        max-width: var(--neon-max-width-page);
+      }
+
+      @include responsive.responsive(tablet) {
+        padding: 0 var(--neon-gutter-tablet);
+        max-width: 100vw;
+      }
+
+      @include responsive.responsive(mobile-large) {
+        padding: 0 var(--neon-gutter-mobile);
+      }
 
       width: 100%;
-      max-width: var(--neon-max-page-width);
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -34,6 +43,13 @@
 
     @include responsive.responsive(mobile-large) {
       height: var(--neon-top-nav-height-mobile);
+    }
+  }
+
+  .neon-page--center {
+    .neon-top-nav__container {
+      margin-left: auto;
+      margin-right: auto;
     }
   }
 }

--- a/src/sass/includes/_layout.scss
+++ b/src/sass/includes/_layout.scss
@@ -161,7 +161,6 @@ $spacings: (
 
 @mixin side-nav-offset {
   @include responsive.responsive(larger-than-tablet) {
-    margin-left: var(--neon-side-nav-width);
-    width: calc(100vw - var(--neon-side-nav-width));
+    padding-left: calc(var(--neon-side-nav-width) + var(--neon-gutter-desktop));
   }
 }

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -9,7 +9,14 @@
   /* layout */
   --neon-base-space: 4rem;
   --neon-max-paragraph-width: 70ch;
-  --neon-max-page-width: 1920rem;
+
+  /* page */
+  --neon-max-width-page: 1920rem;
+
+  /* gutters, all spacings are keyed off these values */
+  --neon-gutter-desktop: 32rem;
+  --neon-gutter-tablet: 24rem;
+  --neon-gutter-mobile: 16rem;
 
   /* spacings */
   --neon-space-1: calc(0.25 * var(--neon-base-space));
@@ -37,7 +44,7 @@
   --neon-space-144: calc(36 * var(--neon-base-space));
   --neon-space-192: calc(48 * var(--neon-base-space));
 
-  /* stack/inline */
+  /* stack & inline gaps */
   --neon-gap-desktop-s: var(--neon-space-4);
   --neon-gap-tablet-s: var(--neon-space-4);
   --neon-gap-mobile-s: var(--neon-space-4);
@@ -52,20 +59,17 @@
 
   /* ratio of horizontal to vertical spacing, e.g. 1 = square padding */
   --neon-spacing-horizontal-multiplier: 1;
-  /* ratio of tablet to mobile spacing */
-  --neon-spacing-multiplier-tablet: 1.5;
-  /* ratio of desktop to mobile spacing */
-  --neon-spacing-multiplier-desktop: 2;
 
+  /* TODO: refactor to remove the usage of these spacings in src/sass/includes/_layout.scss, replace with gutter vars  */
   /* mobile spacing */
-  --neon-spacing-vertical-mobile: var(--neon-space-16);
-  --neon-spacing-horizontal-mobile: calc(var(--neon-spacing-vertical-mobile) * var(--neon-spacing-horizontal-multiplier));
+  --neon-spacing-vertical-mobile: var(--neon-gutter-mobile);
+  --neon-spacing-horizontal-mobile: calc(var(--neon-gutter-mobile) * var(--neon-spacing-horizontal-multiplier));
   /* tablet spacing */
-  --neon-spacing-vertical-tablet: calc(var(--neon-spacing-vertical-mobile) * var(--neon-spacing-multiplier-tablet));
-  --neon-spacing-horizontal-tablet: calc(var(--neon-spacing-horizontal-mobile) * var(--neon-spacing-multiplier-tablet));
+  --neon-spacing-vertical-tablet: var(--neon-gutter-tablet);
+  --neon-spacing-horizontal-tablet: calc(var(--neon-gutter-tablet) * var(--neon-spacing-horizontal-multiplier));
   /* desktop spacing */
-  --neon-spacing-vertical-desktop: calc(var(--neon-spacing-vertical-mobile) * var(--neon-spacing-multiplier-desktop));
-  --neon-spacing-horizontal-desktop: calc(var(--neon-spacing-horizontal-mobile) * var(--neon-spacing-multiplier-desktop));
+  --neon-spacing-vertical-desktop: var(--neon-gutter-desktop);
+  --neon-spacing-horizontal-desktop: calc(var(--neon-gutter-desktop) * var(--neon-spacing-horizontal-multiplier));
 
   /* animation */
   --neon-animation-speed-slow: 0.3s;


### PR DESCRIPTION
## Describe your changes
BREAKING: Add specific slot in `NeonPage` for `NeonFooter`
BREAKING: renamed `--neon-max-page-width` to `--neon-max-width-page`

- Add `pageAlign` property to `NeonPage` to support `Left` or `Center` aligned pages
- Make use of `NeonGrid` as the page container optional
