### PR TITLE
refactor!: input indicator styles

### DIFF
--- a/public/docs/presentation/tabs/NeonTabs.json
+++ b/public/docs/presentation/tabs/NeonTabs.json
@@ -52,6 +52,17 @@
         "func": false,
         "value": "true"
       }
+    },
+    {
+      "name": "fullWidthMobile",
+      "description": "Display tab buttons full screen width at the mobile-large breakpoint.",
+      "type": {
+        "name": "boolean"
+      },
+      "defaultValue": {
+        "func": false,
+        "value": "true"
+      }
     }
   ],
   "events": [

--- a/public/docs/user-input/field-group/NeonFieldGroup.json
+++ b/public/docs/user-input/field-group/NeonFieldGroup.json
@@ -3,6 +3,41 @@
   "description": "Used to compose a group of inputs, buttons and input indicators into a single component.",
   "tags": {},
   "exportName": "default",
+  "props": [
+    {
+      "name": "indicatorStyle",
+      "description": "The style of input indicators to use, either <em>internal</em> where the indicator is inside the adjoined input\nfield or <em>external</em> where the indicator is external to the adjoining field separated by a border & not\nhighlighted as part of the field.",
+      "type": {
+        "name": "String as () => NeonInputIndicatorStyle"
+      },
+      "defaultValue": {
+        "func": false,
+        "value": "NeonInputIndicatorStyle.Internal"
+      }
+    },
+    {
+      "name": "color",
+      "description": "The border highlight color when the indicator style is <em>internal</em>.",
+      "type": {
+        "name": "String as () => NeonFunctionalColor"
+      },
+      "defaultValue": {
+        "func": false,
+        "value": "NeonFunctionalColor.Primary"
+      }
+    },
+    {
+      "name": "disabled",
+      "description": "Use the disabled color styles when the indicator style is <em>internal</em>.",
+      "type": {
+        "name": "boolean"
+      },
+      "defaultValue": {
+        "func": false,
+        "value": "false"
+      }
+    }
+  ],
   "slots": [
     {
       "name": "default",

--- a/src/app/config/enums.json
+++ b/src/app/config/enums.json
@@ -46,7 +46,7 @@
 									"fileName": "NeonAlertLevel.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L13"
 								}
 							],
 							"type": {
@@ -73,7 +73,7 @@
 									"fileName": "NeonAlertLevel.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L7"
 								}
 							],
 							"type": {
@@ -100,7 +100,7 @@
 									"fileName": "NeonAlertLevel.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L9"
 								}
 							],
 							"type": {
@@ -127,7 +127,7 @@
 									"fileName": "NeonAlertLevel.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L11"
 								}
 							],
 							"type": {
@@ -152,7 +152,7 @@
 							"fileName": "NeonAlertLevel.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L5"
 						}
 					]
 				}
@@ -170,7 +170,7 @@
 					"fileName": "NeonAlertLevel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertLevel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertLevel.ts#L1"
 				}
 			]
 		},
@@ -215,7 +215,7 @@
 									"fileName": "NeonAlertPlacement.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L11"
 								}
 							],
 							"type": {
@@ -242,7 +242,7 @@
 									"fileName": "NeonAlertPlacement.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L13"
 								}
 							],
 							"type": {
@@ -269,7 +269,7 @@
 									"fileName": "NeonAlertPlacement.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L7"
 								}
 							],
 							"type": {
@@ -296,7 +296,7 @@
 									"fileName": "NeonAlertPlacement.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L9"
 								}
 							],
 							"type": {
@@ -321,7 +321,7 @@
 							"fileName": "NeonAlertPlacement.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L5"
 						}
 					]
 				}
@@ -339,7 +339,7 @@
 					"fileName": "NeonAlertPlacement.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonAlertPlacement.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonAlertPlacement.ts#L1"
 				}
 			]
 		},
@@ -384,7 +384,7 @@
 									"fileName": "NeonBadgeSize.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L14"
 								}
 							],
 							"type": {
@@ -411,7 +411,7 @@
 									"fileName": "NeonBadgeSize.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L12"
 								}
 							],
 							"type": {
@@ -438,7 +438,7 @@
 									"fileName": "NeonBadgeSize.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L10"
 								}
 							],
 							"type": {
@@ -465,7 +465,7 @@
 									"fileName": "NeonBadgeSize.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L8"
 								}
 							],
 							"type": {
@@ -492,7 +492,7 @@
 									"fileName": "NeonBadgeSize.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L6"
 								}
 							],
 							"type": {
@@ -518,7 +518,7 @@
 							"fileName": "NeonBadgeSize.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L4"
 						}
 					]
 				}
@@ -536,7 +536,7 @@
 					"fileName": "NeonBadgeSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonBadgeSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonBadgeSize.ts#L1"
 				}
 			]
 		},
@@ -581,7 +581,7 @@
 									"fileName": "NeonButtonSize.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L12"
 								}
 							],
 							"type": {
@@ -608,7 +608,7 @@
 									"fileName": "NeonButtonSize.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L10"
 								}
 							],
 							"type": {
@@ -635,7 +635,7 @@
 									"fileName": "NeonButtonSize.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L8"
 								}
 							],
 							"type": {
@@ -662,7 +662,7 @@
 									"fileName": "NeonButtonSize.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L6"
 								}
 							],
 							"type": {
@@ -687,7 +687,7 @@
 							"fileName": "NeonButtonSize.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L4"
 						}
 					]
 				}
@@ -705,7 +705,7 @@
 					"fileName": "NeonButtonSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonSize.ts#L1"
 				}
 			]
 		},
@@ -750,7 +750,7 @@
 									"fileName": "NeonButtonStyle.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L21"
 								}
 							],
 							"type": {
@@ -777,7 +777,7 @@
 									"fileName": "NeonButtonStyle.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L11"
 								}
 							],
 							"type": {
@@ -804,7 +804,7 @@
 									"fileName": "NeonButtonStyle.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L6"
 								}
 							],
 							"type": {
@@ -831,7 +831,7 @@
 									"fileName": "NeonButtonStyle.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L16"
 								}
 							],
 							"type": {
@@ -856,7 +856,7 @@
 							"fileName": "NeonButtonStyle.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L4"
 						}
 					]
 				}
@@ -874,7 +874,7 @@
 					"fileName": "NeonButtonStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonStyle.ts#L1"
 				}
 			]
 		},
@@ -903,7 +903,7 @@
 									"fileName": "NeonButtonType.ts",
 									"line": 2,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonType.ts#L2"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonType.ts#L2"
 								}
 							],
 							"type": {
@@ -922,7 +922,7 @@
 									"fileName": "NeonButtonType.ts",
 									"line": 4,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonType.ts#L4"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonType.ts#L4"
 								}
 							],
 							"type": {
@@ -941,7 +941,7 @@
 									"fileName": "NeonButtonType.ts",
 									"line": 3,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonType.ts#L3"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonType.ts#L3"
 								}
 							],
 							"type": {
@@ -965,7 +965,7 @@
 							"fileName": "NeonButtonType.ts",
 							"line": 1,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonType.ts#L1"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonType.ts#L1"
 						}
 					]
 				}
@@ -983,7 +983,7 @@
 					"fileName": "NeonButtonType.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonButtonType.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonButtonType.ts#L1"
 				}
 			]
 		},
@@ -1028,7 +1028,7 @@
 									"fileName": "NeonChipAction.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonChipAction.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonChipAction.ts#L7"
 								}
 							],
 							"type": {
@@ -1055,7 +1055,7 @@
 									"fileName": "NeonChipAction.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonChipAction.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonChipAction.ts#L9"
 								}
 							],
 							"type": {
@@ -1078,7 +1078,7 @@
 							"fileName": "NeonChipAction.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonChipAction.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonChipAction.ts#L5"
 						}
 					]
 				}
@@ -1096,7 +1096,7 @@
 					"fileName": "NeonChipAction.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonChipAction.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonChipAction.ts#L1"
 				}
 			]
 		},
@@ -1141,7 +1141,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L25"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L25"
 								}
 							],
 							"type": {
@@ -1168,7 +1168,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L27"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L27"
 								}
 							],
 							"type": {
@@ -1195,7 +1195,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 31,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L31"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L31"
 								}
 							],
 							"type": {
@@ -1222,7 +1222,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 29,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L29"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L29"
 								}
 							],
 							"type": {
@@ -1249,7 +1249,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L35"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L35"
 								}
 							],
 							"type": {
@@ -1276,7 +1276,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 33,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L33"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L33"
 								}
 							],
 							"type": {
@@ -1303,7 +1303,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L21"
 								}
 							],
 							"type": {
@@ -1330,7 +1330,7 @@
 									"fileName": "NeonDropdownPlacement.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L23"
 								}
 							],
 							"type": {
@@ -1359,7 +1359,7 @@
 							"fileName": "NeonDropdownPlacement.ts",
 							"line": 19,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L19"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L19"
 						}
 					]
 				}
@@ -1377,7 +1377,7 @@
 					"fileName": "NeonDropdownPlacement.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownPlacement.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownPlacement.ts#L1"
 				}
 			]
 		},
@@ -1422,7 +1422,7 @@
 									"fileName": "NeonDropdownStyle.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L20"
 								}
 							],
 							"type": {
@@ -1449,7 +1449,7 @@
 									"fileName": "NeonDropdownStyle.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L14"
 								}
 							],
 							"type": {
@@ -1476,7 +1476,7 @@
 									"fileName": "NeonDropdownStyle.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L11"
 								}
 							],
 							"type": {
@@ -1503,7 +1503,7 @@
 									"fileName": "NeonDropdownStyle.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L18"
 								}
 							],
 							"type": {
@@ -1530,7 +1530,7 @@
 									"fileName": "NeonDropdownStyle.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L16"
 								}
 							],
 							"type": {
@@ -1556,7 +1556,7 @@
 							"fileName": "NeonDropdownStyle.ts",
 							"line": 9,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L9"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L9"
 						}
 					]
 				}
@@ -1574,7 +1574,7 @@
 					"fileName": "NeonDropdownStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonDropdownStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonDropdownStyle.ts#L1"
 				}
 			]
 		},
@@ -1619,7 +1619,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L16"
 								}
 							],
 							"type": {
@@ -1646,7 +1646,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L26"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L26"
 								}
 							],
 							"type": {
@@ -1673,7 +1673,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L14"
 								}
 							],
 							"type": {
@@ -1700,7 +1700,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L20"
 								}
 							],
 							"type": {
@@ -1727,7 +1727,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L7"
 								}
 							],
 							"type": {
@@ -1754,7 +1754,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L9"
 								}
 							],
 							"type": {
@@ -1781,7 +1781,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L18"
 								}
 							],
 							"type": {
@@ -1808,7 +1808,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L22"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L22"
 								}
 							],
 							"type": {
@@ -1835,7 +1835,7 @@
 									"fileName": "NeonFunctionalColor.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L24"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L24"
 								}
 							],
 							"type": {
@@ -1865,7 +1865,7 @@
 							"fileName": "NeonFunctionalColor.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L5"
 						}
 					]
 				}
@@ -1883,7 +1883,7 @@
 					"fileName": "NeonFunctionalColor.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonFunctionalColor.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonFunctionalColor.ts#L1"
 				}
 			]
 		},
@@ -1928,7 +1928,7 @@
 									"fileName": "NeonHorizontalPosition.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonHorizontalPosition.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonHorizontalPosition.ts#L7"
 								}
 							],
 							"type": {
@@ -1955,7 +1955,7 @@
 									"fileName": "NeonHorizontalPosition.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonHorizontalPosition.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonHorizontalPosition.ts#L9"
 								}
 							],
 							"type": {
@@ -1978,7 +1978,7 @@
 							"fileName": "NeonHorizontalPosition.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonHorizontalPosition.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonHorizontalPosition.ts#L5"
 						}
 					]
 				}
@@ -1996,19 +1996,124 @@
 					"fileName": "NeonHorizontalPosition.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonHorizontalPosition.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonHorizontalPosition.ts#L1"
 				}
 			]
 		},
 		{
 			"id": 73,
-			"name": "NeonInputMode",
+			"name": "NeonInputIndicatorStyle",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
 					"id": 74,
+					"name": "NeonInputIndicatorStyle",
+					"variant": "declaration",
+					"kind": 8,
+					"flags": {},
+					"children": [
+						{
+							"id": 76,
+							"name": "External",
+							"variant": "declaration",
+							"kind": 16,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Display input indicator OUTSIDE the adjacent input."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "NeonInputIndicatorStyle.ts",
+									"line": 9,
+									"character": 2,
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputIndicatorStyle.ts#L9"
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "external"
+							}
+						},
+						{
+							"id": 75,
+							"name": "Internal",
+							"variant": "declaration",
+							"kind": 16,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Display input indicator INSIDE the adjacent input."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "NeonInputIndicatorStyle.ts",
+									"line": 5,
+									"character": 2,
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputIndicatorStyle.ts#L5"
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "internal"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Enumeration Members",
+							"children": [
+								76,
+								75
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "NeonInputIndicatorStyle.ts",
+							"line": 1,
+							"character": 12,
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputIndicatorStyle.ts#L1"
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Enumerations",
+					"children": [
+						74
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "NeonInputIndicatorStyle.ts",
+					"line": 1,
+					"character": 0,
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputIndicatorStyle.ts#L1"
+				}
+			]
+		},
+		{
+			"id": 77,
+			"name": "NeonInputMode",
+			"variant": "declaration",
+			"kind": 2,
+			"flags": {},
+			"children": [
+				{
+					"id": 78,
 					"name": "NeonInputMode",
 					"variant": "declaration",
 					"kind": 8,
@@ -2023,7 +2128,7 @@
 					},
 					"children": [
 						{
-							"id": 77,
+							"id": 81,
 							"name": "Decimal",
 							"variant": "declaration",
 							"kind": 16,
@@ -2041,7 +2146,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L13"
 								}
 							],
 							"type": {
@@ -2050,7 +2155,7 @@
 							}
 						},
 						{
-							"id": 81,
+							"id": 85,
 							"name": "Email",
 							"variant": "declaration",
 							"kind": 16,
@@ -2068,7 +2173,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L24"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L24"
 								}
 							],
 							"type": {
@@ -2077,7 +2182,7 @@
 							}
 						},
 						{
-							"id": 75,
+							"id": 79,
 							"name": "None",
 							"variant": "declaration",
 							"kind": 16,
@@ -2095,7 +2200,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L9"
 								}
 							],
 							"type": {
@@ -2104,7 +2209,7 @@
 							}
 						},
 						{
-							"id": 78,
+							"id": 82,
 							"name": "Numeric",
 							"variant": "declaration",
 							"kind": 16,
@@ -2122,7 +2227,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L15"
 								}
 							],
 							"type": {
@@ -2131,7 +2236,7 @@
 							}
 						},
 						{
-							"id": 80,
+							"id": 84,
 							"name": "Search",
 							"variant": "declaration",
 							"kind": 16,
@@ -2149,7 +2254,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L19"
 								}
 							],
 							"type": {
@@ -2158,7 +2263,7 @@
 							}
 						},
 						{
-							"id": 79,
+							"id": 83,
 							"name": "Tel",
 							"variant": "declaration",
 							"kind": 16,
@@ -2176,7 +2281,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L17"
 								}
 							],
 							"type": {
@@ -2185,7 +2290,7 @@
 							}
 						},
 						{
-							"id": 76,
+							"id": 80,
 							"name": "Text",
 							"variant": "declaration",
 							"kind": 16,
@@ -2203,7 +2308,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L11"
 								}
 							],
 							"type": {
@@ -2212,7 +2317,7 @@
 							}
 						},
 						{
-							"id": 82,
+							"id": 86,
 							"name": "Url",
 							"variant": "declaration",
 							"kind": 16,
@@ -2230,7 +2335,7 @@
 									"fileName": "NeonInputMode.ts",
 									"line": 28,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L28"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L28"
 								}
 							],
 							"type": {
@@ -2243,14 +2348,14 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								77,
 								81,
-								75,
-								78,
-								80,
+								85,
 								79,
-								76,
-								82
+								82,
+								84,
+								83,
+								80,
+								86
 							]
 						}
 					],
@@ -2259,7 +2364,7 @@
 							"fileName": "NeonInputMode.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L7"
 						}
 					]
 				}
@@ -2268,7 +2373,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						74
+						78
 					]
 				}
 			],
@@ -2277,19 +2382,19 @@
 					"fileName": "NeonInputMode.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputMode.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputMode.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 83,
+			"id": 87,
 			"name": "NeonInputType",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 84,
+					"id": 88,
 					"name": "NeonInputType",
 					"variant": "declaration",
 					"kind": 8,
@@ -2304,7 +2409,7 @@
 					},
 					"children": [
 						{
-							"id": 85,
+							"id": 89,
 							"name": "Date",
 							"variant": "declaration",
 							"kind": 16,
@@ -2322,7 +2427,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L9"
 								}
 							],
 							"type": {
@@ -2331,7 +2436,7 @@
 							}
 						},
 						{
-							"id": 86,
+							"id": 90,
 							"name": "DateTime",
 							"variant": "declaration",
 							"kind": 16,
@@ -2349,7 +2454,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L11"
 								}
 							],
 							"type": {
@@ -2358,7 +2463,7 @@
 							}
 						},
 						{
-							"id": 87,
+							"id": 91,
 							"name": "Email",
 							"variant": "declaration",
 							"kind": 16,
@@ -2376,7 +2481,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L13"
 								}
 							],
 							"type": {
@@ -2385,7 +2490,7 @@
 							}
 						},
 						{
-							"id": 88,
+							"id": 92,
 							"name": "File",
 							"variant": "declaration",
 							"kind": 16,
@@ -2403,7 +2508,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L18"
 								}
 							],
 							"type": {
@@ -2412,7 +2517,7 @@
 							}
 						},
 						{
-							"id": 89,
+							"id": 93,
 							"name": "Number",
 							"variant": "declaration",
 							"kind": 16,
@@ -2430,7 +2535,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L20"
 								}
 							],
 							"type": {
@@ -2439,7 +2544,7 @@
 							}
 						},
 						{
-							"id": 90,
+							"id": 94,
 							"name": "Password",
 							"variant": "declaration",
 							"kind": 16,
@@ -2457,7 +2562,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L22"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L22"
 								}
 							],
 							"type": {
@@ -2466,7 +2571,7 @@
 							}
 						},
 						{
-							"id": 91,
+							"id": 95,
 							"name": "Range",
 							"variant": "declaration",
 							"kind": 16,
@@ -2484,7 +2589,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L27"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L27"
 								}
 							],
 							"type": {
@@ -2493,7 +2598,7 @@
 							}
 						},
 						{
-							"id": 92,
+							"id": 96,
 							"name": "Search",
 							"variant": "declaration",
 							"kind": 16,
@@ -2511,7 +2616,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 29,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L29"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L29"
 								}
 							],
 							"type": {
@@ -2520,7 +2625,7 @@
 							}
 						},
 						{
-							"id": 93,
+							"id": 97,
 							"name": "Tel",
 							"variant": "declaration",
 							"kind": 16,
@@ -2538,7 +2643,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 31,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L31"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L31"
 								}
 							],
 							"type": {
@@ -2547,7 +2652,7 @@
 							}
 						},
 						{
-							"id": 94,
+							"id": 98,
 							"name": "Text",
 							"variant": "declaration",
 							"kind": 16,
@@ -2565,7 +2670,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 33,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L33"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L33"
 								}
 							],
 							"type": {
@@ -2574,7 +2679,7 @@
 							}
 						},
 						{
-							"id": 95,
+							"id": 99,
 							"name": "Time",
 							"variant": "declaration",
 							"kind": 16,
@@ -2592,7 +2697,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L35"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L35"
 								}
 							],
 							"type": {
@@ -2601,7 +2706,7 @@
 							}
 						},
 						{
-							"id": 96,
+							"id": 100,
 							"name": "Url",
 							"variant": "declaration",
 							"kind": 16,
@@ -2619,7 +2724,7 @@
 									"fileName": "NeonInputType.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L37"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L37"
 								}
 							],
 							"type": {
@@ -2632,10 +2737,6 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								85,
-								86,
-								87,
-								88,
 								89,
 								90,
 								91,
@@ -2643,7 +2744,11 @@
 								93,
 								94,
 								95,
-								96
+								96,
+								97,
+								98,
+								99,
+								100
 							]
 						}
 					],
@@ -2652,7 +2757,7 @@
 							"fileName": "NeonInputType.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L7"
 						}
 					]
 				}
@@ -2661,7 +2766,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						84
+						88
 					]
 				}
 			],
@@ -2670,19 +2775,19 @@
 					"fileName": "NeonInputType.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonInputType.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonInputType.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 97,
+			"id": 101,
 			"name": "NeonLabelSize",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 98,
+					"id": 102,
 					"name": "NeonLabelSize",
 					"variant": "declaration",
 					"kind": 8,
@@ -2697,7 +2802,7 @@
 					},
 					"children": [
 						{
-							"id": 99,
+							"id": 103,
 							"name": "ExtraExtraSmall",
 							"variant": "declaration",
 							"kind": 16,
@@ -2715,7 +2820,7 @@
 									"fileName": "NeonLabelSize.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L6"
 								}
 							],
 							"type": {
@@ -2724,7 +2829,7 @@
 							}
 						},
 						{
-							"id": 100,
+							"id": 104,
 							"name": "ExtraSmall",
 							"variant": "declaration",
 							"kind": 16,
@@ -2742,7 +2847,7 @@
 									"fileName": "NeonLabelSize.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L8"
 								}
 							],
 							"type": {
@@ -2751,7 +2856,7 @@
 							}
 						},
 						{
-							"id": 103,
+							"id": 107,
 							"name": "Large",
 							"variant": "declaration",
 							"kind": 16,
@@ -2769,7 +2874,7 @@
 									"fileName": "NeonLabelSize.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L14"
 								}
 							],
 							"type": {
@@ -2778,7 +2883,7 @@
 							}
 						},
 						{
-							"id": 102,
+							"id": 106,
 							"name": "Medium",
 							"variant": "declaration",
 							"kind": 16,
@@ -2796,7 +2901,7 @@
 									"fileName": "NeonLabelSize.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L12"
 								}
 							],
 							"type": {
@@ -2805,7 +2910,7 @@
 							}
 						},
 						{
-							"id": 101,
+							"id": 105,
 							"name": "Small",
 							"variant": "declaration",
 							"kind": 16,
@@ -2823,7 +2928,7 @@
 									"fileName": "NeonLabelSize.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L10"
 								}
 							],
 							"type": {
@@ -2836,11 +2941,11 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								99,
-								100,
 								103,
-								102,
-								101
+								104,
+								107,
+								106,
+								105
 							]
 						}
 					],
@@ -2849,7 +2954,7 @@
 							"fileName": "NeonLabelSize.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L4"
 						}
 					]
 				}
@@ -2858,7 +2963,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						98
+						102
 					]
 				}
 			],
@@ -2867,19 +2972,19 @@
 					"fileName": "NeonLabelSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonLabelSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonLabelSize.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 104,
+			"id": 108,
 			"name": "NeonMode",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 105,
+					"id": 109,
 					"name": "NeonMode",
 					"variant": "declaration",
 					"kind": 8,
@@ -2894,7 +2999,7 @@
 					},
 					"children": [
 						{
-							"id": 107,
+							"id": 111,
 							"name": "Dark",
 							"variant": "declaration",
 							"kind": 16,
@@ -2912,7 +3017,7 @@
 									"fileName": "NeonMode.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonMode.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonMode.ts#L8"
 								}
 							],
 							"type": {
@@ -2921,7 +3026,7 @@
 							}
 						},
 						{
-							"id": 106,
+							"id": 110,
 							"name": "Light",
 							"variant": "declaration",
 							"kind": 16,
@@ -2939,7 +3044,7 @@
 									"fileName": "NeonMode.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonMode.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonMode.ts#L6"
 								}
 							],
 							"type": {
@@ -2948,7 +3053,7 @@
 							}
 						},
 						{
-							"id": 108,
+							"id": 112,
 							"name": "System",
 							"variant": "declaration",
 							"kind": 16,
@@ -2966,7 +3071,7 @@
 									"fileName": "NeonMode.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonMode.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonMode.ts#L10"
 								}
 							],
 							"type": {
@@ -2979,9 +3084,9 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								107,
-								106,
-								108
+								111,
+								110,
+								112
 							]
 						}
 					],
@@ -2990,7 +3095,7 @@
 							"fileName": "NeonMode.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonMode.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonMode.ts#L4"
 						}
 					]
 				}
@@ -2999,7 +3104,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						105
+						109
 					]
 				}
 			],
@@ -3008,19 +3113,19 @@
 					"fileName": "NeonMode.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonMode.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonMode.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 109,
+			"id": 113,
 			"name": "NeonOrientation",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 110,
+					"id": 114,
 					"name": "NeonOrientation",
 					"variant": "declaration",
 					"kind": 8,
@@ -3035,7 +3140,7 @@
 					},
 					"children": [
 						{
-							"id": 112,
+							"id": 116,
 							"name": "Horizontal",
 							"variant": "declaration",
 							"kind": 16,
@@ -3053,7 +3158,7 @@
 									"fileName": "NeonOrientation.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOrientation.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOrientation.ts#L9"
 								}
 							],
 							"type": {
@@ -3062,7 +3167,7 @@
 							}
 						},
 						{
-							"id": 111,
+							"id": 115,
 							"name": "Vertical",
 							"variant": "declaration",
 							"kind": 16,
@@ -3080,7 +3185,7 @@
 									"fileName": "NeonOrientation.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOrientation.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOrientation.ts#L7"
 								}
 							],
 							"type": {
@@ -3093,8 +3198,8 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								112,
-								111
+								116,
+								115
 							]
 						}
 					],
@@ -3103,7 +3208,7 @@
 							"fileName": "NeonOrientation.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOrientation.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOrientation.ts#L5"
 						}
 					]
 				}
@@ -3112,7 +3217,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						110
+						114
 					]
 				}
 			],
@@ -3121,19 +3226,19 @@
 					"fileName": "NeonOrientation.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOrientation.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOrientation.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 113,
+			"id": 117,
 			"name": "NeonOutlineStyle",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 114,
+					"id": 118,
 					"name": "NeonOutlineStyle",
 					"variant": "declaration",
 					"kind": 8,
@@ -3148,7 +3253,7 @@
 					},
 					"children": [
 						{
-							"id": 118,
+							"id": 122,
 							"name": "Background",
 							"variant": "declaration",
 							"kind": 16,
@@ -3166,7 +3271,7 @@
 									"fileName": "NeonOutlineStyle.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L15"
 								}
 							],
 							"type": {
@@ -3175,7 +3280,7 @@
 							}
 						},
 						{
-							"id": 117,
+							"id": 121,
 							"name": "Border",
 							"variant": "declaration",
 							"kind": 16,
@@ -3193,7 +3298,7 @@
 									"fileName": "NeonOutlineStyle.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L13"
 								}
 							],
 							"type": {
@@ -3202,7 +3307,7 @@
 							}
 						},
 						{
-							"id": 119,
+							"id": 123,
 							"name": "Bullet",
 							"variant": "declaration",
 							"kind": 16,
@@ -3220,7 +3325,7 @@
 									"fileName": "NeonOutlineStyle.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L17"
 								}
 							],
 							"type": {
@@ -3229,7 +3334,7 @@
 							}
 						},
 						{
-							"id": 115,
+							"id": 119,
 							"name": "None",
 							"variant": "declaration",
 							"kind": 16,
@@ -3247,7 +3352,7 @@
 									"fileName": "NeonOutlineStyle.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L9"
 								}
 							],
 							"type": {
@@ -3256,7 +3361,7 @@
 							}
 						},
 						{
-							"id": 116,
+							"id": 120,
 							"name": "Text",
 							"variant": "declaration",
 							"kind": 16,
@@ -3274,7 +3379,7 @@
 									"fileName": "NeonOutlineStyle.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L11"
 								}
 							],
 							"type": {
@@ -3287,11 +3392,11 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								118,
-								117,
+								122,
+								121,
+								123,
 								119,
-								115,
-								116
+								120
 							]
 						}
 					],
@@ -3300,7 +3405,7 @@
 							"fileName": "NeonOutlineStyle.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L7"
 						}
 					]
 				}
@@ -3309,7 +3414,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						114
+						118
 					]
 				}
 			],
@@ -3318,26 +3423,26 @@
 					"fileName": "NeonOutlineStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonOutlineStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonOutlineStyle.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 120,
+			"id": 124,
 			"name": "NeonPageAlignment",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 121,
+					"id": 125,
 					"name": "NeonPageAlignment",
 					"variant": "declaration",
 					"kind": 8,
 					"flags": {},
 					"children": [
 						{
-							"id": 122,
+							"id": 126,
 							"name": "CENTER",
 							"variant": "declaration",
 							"kind": 16,
@@ -3347,7 +3452,7 @@
 									"fileName": "NeonPageAlignment.ts",
 									"line": 2,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPageAlignment.ts#L2"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPageAlignment.ts#L2"
 								}
 							],
 							"type": {
@@ -3356,7 +3461,7 @@
 							}
 						},
 						{
-							"id": 123,
+							"id": 127,
 							"name": "LEFT",
 							"variant": "declaration",
 							"kind": 16,
@@ -3366,7 +3471,7 @@
 									"fileName": "NeonPageAlignment.ts",
 									"line": 3,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPageAlignment.ts#L3"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPageAlignment.ts#L3"
 								}
 							],
 							"type": {
@@ -3379,8 +3484,8 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								122,
-								123
+								126,
+								127
 							]
 						}
 					],
@@ -3389,7 +3494,7 @@
 							"fileName": "NeonPageAlignment.ts",
 							"line": 1,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPageAlignment.ts#L1"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPageAlignment.ts#L1"
 						}
 					]
 				}
@@ -3398,7 +3503,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						121
+						125
 					]
 				}
 			],
@@ -3407,19 +3512,19 @@
 					"fileName": "NeonPageAlignment.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPageAlignment.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPageAlignment.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 124,
+			"id": 128,
 			"name": "NeonPosition",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 125,
+					"id": 129,
 					"name": "NeonPosition",
 					"variant": "declaration",
 					"kind": 8,
@@ -3434,7 +3539,7 @@
 					},
 					"children": [
 						{
-							"id": 128,
+							"id": 132,
 							"name": "Bottom",
 							"variant": "declaration",
 							"kind": 16,
@@ -3452,7 +3557,7 @@
 									"fileName": "NeonPosition.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L11"
 								}
 							],
 							"type": {
@@ -3461,7 +3566,7 @@
 							}
 						},
 						{
-							"id": 127,
+							"id": 131,
 							"name": "Left",
 							"variant": "declaration",
 							"kind": 16,
@@ -3479,7 +3584,7 @@
 									"fileName": "NeonPosition.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L9"
 								}
 							],
 							"type": {
@@ -3488,7 +3593,7 @@
 							}
 						},
 						{
-							"id": 129,
+							"id": 133,
 							"name": "Right",
 							"variant": "declaration",
 							"kind": 16,
@@ -3506,7 +3611,7 @@
 									"fileName": "NeonPosition.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L13"
 								}
 							],
 							"type": {
@@ -3515,7 +3620,7 @@
 							}
 						},
 						{
-							"id": 126,
+							"id": 130,
 							"name": "Top",
 							"variant": "declaration",
 							"kind": 16,
@@ -3533,7 +3638,7 @@
 									"fileName": "NeonPosition.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L7"
 								}
 							],
 							"type": {
@@ -3546,10 +3651,10 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								128,
-								127,
-								129,
-								126
+								132,
+								131,
+								133,
+								130
 							]
 						}
 					],
@@ -3558,7 +3663,7 @@
 							"fileName": "NeonPosition.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L5"
 						}
 					]
 				}
@@ -3567,7 +3672,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						125
+						129
 					]
 				}
 			],
@@ -3576,19 +3681,19 @@
 					"fileName": "NeonPosition.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonPosition.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonPosition.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 130,
+			"id": 134,
 			"name": "NeonResponsive",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 131,
+					"id": 135,
 					"name": "NeonResponsive",
 					"variant": "declaration",
 					"kind": 8,
@@ -3603,7 +3708,7 @@
 					},
 					"children": [
 						{
-							"id": 132,
+							"id": 136,
 							"name": "All",
 							"variant": "declaration",
 							"kind": 16,
@@ -3621,7 +3726,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L11"
 								}
 							],
 							"type": {
@@ -3630,7 +3735,7 @@
 							}
 						},
 						{
-							"id": 133,
+							"id": 137,
 							"name": "Desktop",
 							"variant": "declaration",
 							"kind": 16,
@@ -3648,7 +3753,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L13"
 								}
 							],
 							"type": {
@@ -3657,7 +3762,7 @@
 							}
 						},
 						{
-							"id": 134,
+							"id": 138,
 							"name": "DesktopLarge",
 							"variant": "declaration",
 							"kind": 16,
@@ -3675,7 +3780,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L15"
 								}
 							],
 							"type": {
@@ -3684,7 +3789,7 @@
 							}
 						},
 						{
-							"id": 139,
+							"id": 143,
 							"name": "LargerThanMobile",
 							"variant": "declaration",
 							"kind": 16,
@@ -3702,7 +3807,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L25"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L25"
 								}
 							],
 							"type": {
@@ -3711,7 +3816,7 @@
 							}
 						},
 						{
-							"id": 137,
+							"id": 141,
 							"name": "LargerThanMobileLarge",
 							"variant": "declaration",
 							"kind": 16,
@@ -3729,7 +3834,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L21"
 								}
 							],
 							"type": {
@@ -3738,7 +3843,7 @@
 							}
 						},
 						{
-							"id": 135,
+							"id": 139,
 							"name": "LargerThanTablet",
 							"variant": "declaration",
 							"kind": 16,
@@ -3756,7 +3861,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L17"
 								}
 							],
 							"type": {
@@ -3765,7 +3870,7 @@
 							}
 						},
 						{
-							"id": 140,
+							"id": 144,
 							"name": "Mobile",
 							"variant": "declaration",
 							"kind": 16,
@@ -3783,7 +3888,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L27"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L27"
 								}
 							],
 							"type": {
@@ -3792,7 +3897,7 @@
 							}
 						},
 						{
-							"id": 138,
+							"id": 142,
 							"name": "MobileLarge",
 							"variant": "declaration",
 							"kind": 16,
@@ -3810,7 +3915,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L23"
 								}
 							],
 							"type": {
@@ -3819,7 +3924,7 @@
 							}
 						},
 						{
-							"id": 136,
+							"id": 140,
 							"name": "Tablet",
 							"variant": "declaration",
 							"kind": 16,
@@ -3837,7 +3942,7 @@
 									"fileName": "NeonResponsive.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L19"
 								}
 							],
 							"type": {
@@ -3850,15 +3955,15 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								132,
-								133,
-								134,
-								139,
+								136,
 								137,
-								135,
-								140,
 								138,
-								136
+								143,
+								141,
+								139,
+								144,
+								142,
+								140
 							]
 						}
 					],
@@ -3867,7 +3972,7 @@
 							"fileName": "NeonResponsive.ts",
 							"line": 6,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L6"
 						}
 					]
 				}
@@ -3876,7 +3981,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						131
+						135
 					]
 				}
 			],
@@ -3885,19 +3990,19 @@
 					"fileName": "NeonResponsive.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonResponsive.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonResponsive.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 141,
+			"id": 145,
 			"name": "NeonSize",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 142,
+					"id": 146,
 					"name": "NeonSize",
 					"variant": "declaration",
 					"kind": 8,
@@ -3912,7 +4017,7 @@
 					},
 					"children": [
 						{
-							"id": 145,
+							"id": 149,
 							"name": "Large",
 							"variant": "declaration",
 							"kind": 16,
@@ -3930,7 +4035,7 @@
 									"fileName": "NeonSize.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSize.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSize.ts#L11"
 								}
 							],
 							"type": {
@@ -3939,7 +4044,7 @@
 							}
 						},
 						{
-							"id": 144,
+							"id": 148,
 							"name": "Medium",
 							"variant": "declaration",
 							"kind": 16,
@@ -3957,7 +4062,7 @@
 									"fileName": "NeonSize.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSize.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSize.ts#L9"
 								}
 							],
 							"type": {
@@ -3966,7 +4071,7 @@
 							}
 						},
 						{
-							"id": 143,
+							"id": 147,
 							"name": "Small",
 							"variant": "declaration",
 							"kind": 16,
@@ -3984,7 +4089,7 @@
 									"fileName": "NeonSize.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSize.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSize.ts#L7"
 								}
 							],
 							"type": {
@@ -3997,9 +4102,9 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								145,
-								144,
-								143
+								149,
+								148,
+								147
 							]
 						}
 					],
@@ -4008,7 +4113,7 @@
 							"fileName": "NeonSize.ts",
 							"line": 5,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSize.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSize.ts#L5"
 						}
 					]
 				}
@@ -4017,7 +4122,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						142
+						146
 					]
 				}
 			],
@@ -4026,19 +4131,19 @@
 					"fileName": "NeonSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSize.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 146,
+			"id": 150,
 			"name": "NeonSplashLoaderSize",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 147,
+					"id": 151,
 					"name": "NeonSplashLoaderSize",
 					"variant": "declaration",
 					"kind": 8,
@@ -4053,7 +4158,7 @@
 					},
 					"children": [
 						{
-							"id": 151,
+							"id": 155,
 							"name": "ExtraLarge",
 							"variant": "declaration",
 							"kind": 16,
@@ -4071,7 +4176,7 @@
 									"fileName": "NeonSplashLoaderSize.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L12"
 								}
 							],
 							"type": {
@@ -4080,7 +4185,7 @@
 							}
 						},
 						{
-							"id": 150,
+							"id": 154,
 							"name": "Large",
 							"variant": "declaration",
 							"kind": 16,
@@ -4098,7 +4203,7 @@
 									"fileName": "NeonSplashLoaderSize.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L10"
 								}
 							],
 							"type": {
@@ -4107,7 +4212,7 @@
 							}
 						},
 						{
-							"id": 149,
+							"id": 153,
 							"name": "Medium",
 							"variant": "declaration",
 							"kind": 16,
@@ -4125,7 +4230,7 @@
 									"fileName": "NeonSplashLoaderSize.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L8"
 								}
 							],
 							"type": {
@@ -4134,7 +4239,7 @@
 							}
 						},
 						{
-							"id": 148,
+							"id": 152,
 							"name": "Small",
 							"variant": "declaration",
 							"kind": 16,
@@ -4152,7 +4257,7 @@
 									"fileName": "NeonSplashLoaderSize.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L6"
 								}
 							],
 							"type": {
@@ -4165,10 +4270,10 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								151,
-								150,
-								149,
-								148
+								155,
+								154,
+								153,
+								152
 							]
 						}
 					],
@@ -4177,7 +4282,7 @@
 							"fileName": "NeonSplashLoaderSize.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L4"
 						}
 					]
 				}
@@ -4186,7 +4291,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						147
+						151
 					]
 				}
 			],
@@ -4195,19 +4300,19 @@
 					"fileName": "NeonSplashLoaderSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSplashLoaderSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSplashLoaderSize.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 152,
+			"id": 156,
 			"name": "NeonState",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 153,
+					"id": 157,
 					"name": "NeonState",
 					"variant": "declaration",
 					"kind": 8,
@@ -4222,7 +4327,7 @@
 					},
 					"children": [
 						{
-							"id": 157,
+							"id": 161,
 							"name": "Error",
 							"variant": "declaration",
 							"kind": 16,
@@ -4240,7 +4345,7 @@
 									"fileName": "NeonState.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L21"
 								}
 							],
 							"type": {
@@ -4249,7 +4354,7 @@
 							}
 						},
 						{
-							"id": 155,
+							"id": 159,
 							"name": "Loading",
 							"variant": "declaration",
 							"kind": 16,
@@ -4267,7 +4372,7 @@
 									"fileName": "NeonState.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L11"
 								}
 							],
 							"type": {
@@ -4276,7 +4381,7 @@
 							}
 						},
 						{
-							"id": 154,
+							"id": 158,
 							"name": "Ready",
 							"variant": "declaration",
 							"kind": 16,
@@ -4294,7 +4399,7 @@
 									"fileName": "NeonState.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L6"
 								}
 							],
 							"type": {
@@ -4303,7 +4408,7 @@
 							}
 						},
 						{
-							"id": 156,
+							"id": 160,
 							"name": "Success",
 							"variant": "declaration",
 							"kind": 16,
@@ -4321,7 +4426,7 @@
 									"fileName": "NeonState.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L16"
 								}
 							],
 							"type": {
@@ -4334,10 +4439,10 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								157,
-								155,
-								154,
-								156
+								161,
+								159,
+								158,
+								160
 							]
 						}
 					],
@@ -4346,7 +4451,7 @@
 							"fileName": "NeonState.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L4"
 						}
 					]
 				}
@@ -4355,7 +4460,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						153
+						157
 					]
 				}
 			],
@@ -4364,19 +4469,19 @@
 					"fileName": "NeonState.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonState.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonState.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 158,
+			"id": 162,
 			"name": "NeonSwitchStyle",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 159,
+					"id": 163,
 					"name": "NeonSwitchStyle",
 					"variant": "declaration",
 					"kind": 8,
@@ -4391,7 +4496,7 @@
 					},
 					"children": [
 						{
-							"id": 161,
+							"id": 165,
 							"name": "Checkbox",
 							"variant": "declaration",
 							"kind": 16,
@@ -4409,7 +4514,7 @@
 									"fileName": "NeonSwitchStyle.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSwitchStyle.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSwitchStyle.ts#L8"
 								}
 							],
 							"type": {
@@ -4418,7 +4523,7 @@
 							}
 						},
 						{
-							"id": 160,
+							"id": 164,
 							"name": "Switch",
 							"variant": "declaration",
 							"kind": 16,
@@ -4436,7 +4541,7 @@
 									"fileName": "NeonSwitchStyle.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSwitchStyle.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSwitchStyle.ts#L6"
 								}
 							],
 							"type": {
@@ -4449,8 +4554,8 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								161,
-								160
+								165,
+								164
 							]
 						}
 					],
@@ -4459,7 +4564,7 @@
 							"fileName": "NeonSwitchStyle.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSwitchStyle.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSwitchStyle.ts#L4"
 						}
 					]
 				}
@@ -4468,7 +4573,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						159
+						163
 					]
 				}
 			],
@@ -4477,19 +4582,19 @@
 					"fileName": "NeonSwitchStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonSwitchStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonSwitchStyle.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 162,
+			"id": 166,
 			"name": "NeonToggleChipSize",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 163,
+					"id": 167,
 					"name": "NeonToggleChipSize",
 					"variant": "declaration",
 					"kind": 8,
@@ -4504,7 +4609,7 @@
 					},
 					"children": [
 						{
-							"id": 164,
+							"id": 168,
 							"name": "ExtraSmall",
 							"variant": "declaration",
 							"kind": 16,
@@ -4522,7 +4627,7 @@
 									"fileName": "NeonToggleChipSize.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L6"
 								}
 							],
 							"type": {
@@ -4531,7 +4636,7 @@
 							}
 						},
 						{
-							"id": 167,
+							"id": 171,
 							"name": "Large",
 							"variant": "declaration",
 							"kind": 16,
@@ -4549,7 +4654,7 @@
 									"fileName": "NeonToggleChipSize.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L12"
 								}
 							],
 							"type": {
@@ -4558,7 +4663,7 @@
 							}
 						},
 						{
-							"id": 166,
+							"id": 170,
 							"name": "Medium",
 							"variant": "declaration",
 							"kind": 16,
@@ -4576,7 +4681,7 @@
 									"fileName": "NeonToggleChipSize.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L10"
 								}
 							],
 							"type": {
@@ -4585,7 +4690,7 @@
 							}
 						},
 						{
-							"id": 165,
+							"id": 169,
 							"name": "Small",
 							"variant": "declaration",
 							"kind": 16,
@@ -4603,7 +4708,7 @@
 									"fileName": "NeonToggleChipSize.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L8"
 								}
 							],
 							"type": {
@@ -4616,10 +4721,10 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								164,
-								167,
-								166,
-								165
+								168,
+								171,
+								170,
+								169
 							]
 						}
 					],
@@ -4628,7 +4733,7 @@
 							"fileName": "NeonToggleChipSize.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L4"
 						}
 					]
 				}
@@ -4637,7 +4742,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						163
+						167
 					]
 				}
 			],
@@ -4646,19 +4751,19 @@
 					"fileName": "NeonToggleChipSize.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleChipSize.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleChipSize.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 168,
+			"id": 172,
 			"name": "NeonToggleStyle",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 169,
+					"id": 173,
 					"name": "NeonToggleStyle",
 					"variant": "declaration",
 					"kind": 8,
@@ -4673,7 +4778,7 @@
 					},
 					"children": [
 						{
-							"id": 172,
+							"id": 176,
 							"name": "Card",
 							"variant": "declaration",
 							"kind": 16,
@@ -4691,7 +4796,7 @@
 									"fileName": "NeonToggleStyle.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleStyle.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleStyle.ts#L10"
 								}
 							],
 							"type": {
@@ -4700,7 +4805,7 @@
 							}
 						},
 						{
-							"id": 171,
+							"id": 175,
 							"name": "RadioButtons",
 							"variant": "declaration",
 							"kind": 16,
@@ -4718,7 +4823,7 @@
 									"fileName": "NeonToggleStyle.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleStyle.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleStyle.ts#L8"
 								}
 							],
 							"type": {
@@ -4727,7 +4832,7 @@
 							}
 						},
 						{
-							"id": 170,
+							"id": 174,
 							"name": "Toggle",
 							"variant": "declaration",
 							"kind": 16,
@@ -4745,7 +4850,7 @@
 									"fileName": "NeonToggleStyle.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleStyle.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleStyle.ts#L6"
 								}
 							],
 							"type": {
@@ -4758,9 +4863,9 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								172,
-								171,
-								170
+								176,
+								175,
+								174
 							]
 						}
 					],
@@ -4769,7 +4874,7 @@
 							"fileName": "NeonToggleStyle.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleStyle.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleStyle.ts#L4"
 						}
 					]
 				}
@@ -4778,7 +4883,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						169
+						173
 					]
 				}
 			],
@@ -4787,19 +4892,19 @@
 					"fileName": "NeonToggleStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonToggleStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonToggleStyle.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 173,
+			"id": 177,
 			"name": "NeonTooltipStyle",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 174,
+					"id": 178,
 					"name": "NeonTooltipStyle",
 					"variant": "declaration",
 					"kind": 8,
@@ -4814,7 +4919,7 @@
 					},
 					"children": [
 						{
-							"id": 176,
+							"id": 180,
 							"name": "Popover",
 							"variant": "declaration",
 							"kind": 16,
@@ -4832,7 +4937,7 @@
 									"fileName": "NeonTooltipStyle.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonTooltipStyle.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonTooltipStyle.ts#L8"
 								}
 							],
 							"type": {
@@ -4841,7 +4946,7 @@
 							}
 						},
 						{
-							"id": 175,
+							"id": 179,
 							"name": "Tooltip",
 							"variant": "declaration",
 							"kind": 16,
@@ -4859,7 +4964,7 @@
 									"fileName": "NeonTooltipStyle.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonTooltipStyle.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonTooltipStyle.ts#L6"
 								}
 							],
 							"type": {
@@ -4872,8 +4977,8 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								176,
-								175
+								180,
+								179
 							]
 						}
 					],
@@ -4882,7 +4987,7 @@
 							"fileName": "NeonTooltipStyle.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonTooltipStyle.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonTooltipStyle.ts#L4"
 						}
 					]
 				}
@@ -4891,7 +4996,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						174
+						178
 					]
 				}
 			],
@@ -4900,19 +5005,19 @@
 					"fileName": "NeonTooltipStyle.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonTooltipStyle.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonTooltipStyle.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 177,
+			"id": 181,
 			"name": "NeonVerticalPosition",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 178,
+					"id": 182,
 					"name": "NeonVerticalPosition",
 					"variant": "declaration",
 					"kind": 8,
@@ -4927,7 +5032,7 @@
 					},
 					"children": [
 						{
-							"id": 180,
+							"id": 184,
 							"name": "Bottom",
 							"variant": "declaration",
 							"kind": 16,
@@ -4945,7 +5050,7 @@
 									"fileName": "NeonVerticalPosition.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonVerticalPosition.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonVerticalPosition.ts#L8"
 								}
 							],
 							"type": {
@@ -4954,7 +5059,7 @@
 							}
 						},
 						{
-							"id": 179,
+							"id": 183,
 							"name": "Top",
 							"variant": "declaration",
 							"kind": 16,
@@ -4972,7 +5077,7 @@
 									"fileName": "NeonVerticalPosition.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonVerticalPosition.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonVerticalPosition.ts#L6"
 								}
 							],
 							"type": {
@@ -4985,8 +5090,8 @@
 						{
 							"title": "Enumeration Members",
 							"children": [
-								180,
-								179
+								184,
+								183
 							]
 						}
 					],
@@ -4995,7 +5100,7 @@
 							"fileName": "NeonVerticalPosition.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonVerticalPosition.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonVerticalPosition.ts#L4"
 						}
 					]
 				}
@@ -5004,7 +5109,7 @@
 				{
 					"title": "Enumerations",
 					"children": [
-						178
+						182
 					]
 				}
 			],
@@ -5013,7 +5118,7 @@
 					"fileName": "NeonVerticalPosition.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/enums/NeonVerticalPosition.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/enums/NeonVerticalPosition.ts#L1"
 				}
 			]
 		}
@@ -5034,22 +5139,23 @@
 				58,
 				69,
 				73,
-				83,
-				97,
-				104,
-				109,
+				77,
+				87,
+				101,
+				108,
 				113,
-				120,
+				117,
 				124,
-				130,
-				141,
-				146,
-				152,
-				158,
+				128,
+				134,
+				145,
+				150,
+				156,
 				162,
-				168,
-				173,
-				177
+				166,
+				172,
+				177,
+				181
 			]
 		}
 	],
@@ -5350,434 +5456,450 @@
 			"qualifiedName": "NeonHorizontalPosition.Right"
 		},
 		"73": {
-			"sourceFileName": "src/common/enums/NeonInputMode.ts",
+			"sourceFileName": "src/common/enums/NeonInputIndicatorStyle.ts",
 			"qualifiedName": ""
 		},
 		"74": {
-			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode"
+			"sourceFileName": "src/common/enums/NeonInputIndicatorStyle.ts",
+			"qualifiedName": "NeonInputIndicatorStyle"
 		},
 		"75": {
-			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.None"
+			"sourceFileName": "src/common/enums/NeonInputIndicatorStyle.ts",
+			"qualifiedName": "NeonInputIndicatorStyle.Internal"
 		},
 		"76": {
-			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Text"
+			"sourceFileName": "src/common/enums/NeonInputIndicatorStyle.ts",
+			"qualifiedName": "NeonInputIndicatorStyle.External"
 		},
 		"77": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Decimal"
+			"qualifiedName": ""
 		},
 		"78": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Numeric"
+			"qualifiedName": "NeonInputMode"
 		},
 		"79": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Tel"
+			"qualifiedName": "NeonInputMode.None"
 		},
 		"80": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Search"
+			"qualifiedName": "NeonInputMode.Text"
 		},
 		"81": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Email"
+			"qualifiedName": "NeonInputMode.Decimal"
 		},
 		"82": {
 			"sourceFileName": "src/common/enums/NeonInputMode.ts",
-			"qualifiedName": "NeonInputMode.Url"
+			"qualifiedName": "NeonInputMode.Numeric"
 		},
 		"83": {
-			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonInputMode.ts",
+			"qualifiedName": "NeonInputMode.Tel"
 		},
 		"84": {
-			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType"
+			"sourceFileName": "src/common/enums/NeonInputMode.ts",
+			"qualifiedName": "NeonInputMode.Search"
 		},
 		"85": {
-			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Date"
+			"sourceFileName": "src/common/enums/NeonInputMode.ts",
+			"qualifiedName": "NeonInputMode.Email"
 		},
 		"86": {
-			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.DateTime"
+			"sourceFileName": "src/common/enums/NeonInputMode.ts",
+			"qualifiedName": "NeonInputMode.Url"
 		},
 		"87": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Email"
+			"qualifiedName": ""
 		},
 		"88": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.File"
+			"qualifiedName": "NeonInputType"
 		},
 		"89": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Number"
+			"qualifiedName": "NeonInputType.Date"
 		},
 		"90": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Password"
+			"qualifiedName": "NeonInputType.DateTime"
 		},
 		"91": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Range"
+			"qualifiedName": "NeonInputType.Email"
 		},
 		"92": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Search"
+			"qualifiedName": "NeonInputType.File"
 		},
 		"93": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Tel"
+			"qualifiedName": "NeonInputType.Number"
 		},
 		"94": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Text"
+			"qualifiedName": "NeonInputType.Password"
 		},
 		"95": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Time"
+			"qualifiedName": "NeonInputType.Range"
 		},
 		"96": {
 			"sourceFileName": "src/common/enums/NeonInputType.ts",
-			"qualifiedName": "NeonInputType.Url"
+			"qualifiedName": "NeonInputType.Search"
 		},
 		"97": {
-			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonInputType.ts",
+			"qualifiedName": "NeonInputType.Tel"
 		},
 		"98": {
-			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize"
+			"sourceFileName": "src/common/enums/NeonInputType.ts",
+			"qualifiedName": "NeonInputType.Text"
 		},
 		"99": {
-			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize.ExtraExtraSmall"
+			"sourceFileName": "src/common/enums/NeonInputType.ts",
+			"qualifiedName": "NeonInputType.Time"
 		},
 		"100": {
-			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize.ExtraSmall"
+			"sourceFileName": "src/common/enums/NeonInputType.ts",
+			"qualifiedName": "NeonInputType.Url"
 		},
 		"101": {
 			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize.Small"
+			"qualifiedName": ""
 		},
 		"102": {
 			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize.Medium"
+			"qualifiedName": "NeonLabelSize"
 		},
 		"103": {
 			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
-			"qualifiedName": "NeonLabelSize.Large"
+			"qualifiedName": "NeonLabelSize.ExtraExtraSmall"
 		},
 		"104": {
-			"sourceFileName": "src/common/enums/NeonMode.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
+			"qualifiedName": "NeonLabelSize.ExtraSmall"
 		},
 		"105": {
-			"sourceFileName": "src/common/enums/NeonMode.ts",
-			"qualifiedName": "NeonMode"
+			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
+			"qualifiedName": "NeonLabelSize.Small"
 		},
 		"106": {
-			"sourceFileName": "src/common/enums/NeonMode.ts",
-			"qualifiedName": "NeonMode.Light"
+			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
+			"qualifiedName": "NeonLabelSize.Medium"
 		},
 		"107": {
-			"sourceFileName": "src/common/enums/NeonMode.ts",
-			"qualifiedName": "NeonMode.Dark"
+			"sourceFileName": "src/common/enums/NeonLabelSize.ts",
+			"qualifiedName": "NeonLabelSize.Large"
 		},
 		"108": {
 			"sourceFileName": "src/common/enums/NeonMode.ts",
-			"qualifiedName": "NeonMode.System"
-		},
-		"109": {
-			"sourceFileName": "src/common/enums/NeonOrientation.ts",
 			"qualifiedName": ""
 		},
+		"109": {
+			"sourceFileName": "src/common/enums/NeonMode.ts",
+			"qualifiedName": "NeonMode"
+		},
 		"110": {
-			"sourceFileName": "src/common/enums/NeonOrientation.ts",
-			"qualifiedName": "NeonOrientation"
+			"sourceFileName": "src/common/enums/NeonMode.ts",
+			"qualifiedName": "NeonMode.Light"
 		},
 		"111": {
-			"sourceFileName": "src/common/enums/NeonOrientation.ts",
-			"qualifiedName": "NeonOrientation.Vertical"
+			"sourceFileName": "src/common/enums/NeonMode.ts",
+			"qualifiedName": "NeonMode.Dark"
 		},
 		"112": {
-			"sourceFileName": "src/common/enums/NeonOrientation.ts",
-			"qualifiedName": "NeonOrientation.Horizontal"
+			"sourceFileName": "src/common/enums/NeonMode.ts",
+			"qualifiedName": "NeonMode.System"
 		},
 		"113": {
-			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
+			"sourceFileName": "src/common/enums/NeonOrientation.ts",
 			"qualifiedName": ""
 		},
 		"114": {
-			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle"
+			"sourceFileName": "src/common/enums/NeonOrientation.ts",
+			"qualifiedName": "NeonOrientation"
 		},
 		"115": {
-			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle.None"
+			"sourceFileName": "src/common/enums/NeonOrientation.ts",
+			"qualifiedName": "NeonOrientation.Vertical"
 		},
 		"116": {
-			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle.Text"
+			"sourceFileName": "src/common/enums/NeonOrientation.ts",
+			"qualifiedName": "NeonOrientation.Horizontal"
 		},
 		"117": {
 			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle.Border"
+			"qualifiedName": ""
 		},
 		"118": {
 			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle.Background"
+			"qualifiedName": "NeonOutlineStyle"
 		},
 		"119": {
 			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
-			"qualifiedName": "NeonOutlineStyle.Bullet"
+			"qualifiedName": "NeonOutlineStyle.None"
 		},
 		"120": {
-			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
+			"qualifiedName": "NeonOutlineStyle.Text"
 		},
 		"121": {
-			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
-			"qualifiedName": "NeonPageAlignment"
+			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
+			"qualifiedName": "NeonOutlineStyle.Border"
 		},
 		"122": {
-			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
-			"qualifiedName": "NeonPageAlignment.CENTER"
+			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
+			"qualifiedName": "NeonOutlineStyle.Background"
 		},
 		"123": {
-			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
-			"qualifiedName": "NeonPageAlignment.LEFT"
+			"sourceFileName": "src/common/enums/NeonOutlineStyle.ts",
+			"qualifiedName": "NeonOutlineStyle.Bullet"
 		},
 		"124": {
-			"sourceFileName": "src/common/enums/NeonPosition.ts",
+			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
 			"qualifiedName": ""
 		},
 		"125": {
-			"sourceFileName": "src/common/enums/NeonPosition.ts",
-			"qualifiedName": "NeonPosition"
+			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
+			"qualifiedName": "NeonPageAlignment"
 		},
 		"126": {
-			"sourceFileName": "src/common/enums/NeonPosition.ts",
-			"qualifiedName": "NeonPosition.Top"
+			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
+			"qualifiedName": "NeonPageAlignment.CENTER"
 		},
 		"127": {
-			"sourceFileName": "src/common/enums/NeonPosition.ts",
-			"qualifiedName": "NeonPosition.Left"
+			"sourceFileName": "src/common/enums/NeonPageAlignment.ts",
+			"qualifiedName": "NeonPageAlignment.LEFT"
 		},
 		"128": {
 			"sourceFileName": "src/common/enums/NeonPosition.ts",
-			"qualifiedName": "NeonPosition.Bottom"
+			"qualifiedName": ""
 		},
 		"129": {
 			"sourceFileName": "src/common/enums/NeonPosition.ts",
-			"qualifiedName": "NeonPosition.Right"
+			"qualifiedName": "NeonPosition"
 		},
 		"130": {
-			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonPosition.ts",
+			"qualifiedName": "NeonPosition.Top"
 		},
 		"131": {
-			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive"
+			"sourceFileName": "src/common/enums/NeonPosition.ts",
+			"qualifiedName": "NeonPosition.Left"
 		},
 		"132": {
-			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.All"
+			"sourceFileName": "src/common/enums/NeonPosition.ts",
+			"qualifiedName": "NeonPosition.Bottom"
 		},
 		"133": {
-			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.Desktop"
+			"sourceFileName": "src/common/enums/NeonPosition.ts",
+			"qualifiedName": "NeonPosition.Right"
 		},
 		"134": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.DesktopLarge"
+			"qualifiedName": ""
 		},
 		"135": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.LargerThanTablet"
+			"qualifiedName": "NeonResponsive"
 		},
 		"136": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.Tablet"
+			"qualifiedName": "NeonResponsive.All"
 		},
 		"137": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.LargerThanMobileLarge"
+			"qualifiedName": "NeonResponsive.Desktop"
 		},
 		"138": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.MobileLarge"
+			"qualifiedName": "NeonResponsive.DesktopLarge"
 		},
 		"139": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.LargerThanMobile"
+			"qualifiedName": "NeonResponsive.LargerThanTablet"
 		},
 		"140": {
 			"sourceFileName": "src/common/enums/NeonResponsive.ts",
-			"qualifiedName": "NeonResponsive.Mobile"
+			"qualifiedName": "NeonResponsive.Tablet"
 		},
 		"141": {
-			"sourceFileName": "src/common/enums/NeonSize.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonResponsive.ts",
+			"qualifiedName": "NeonResponsive.LargerThanMobileLarge"
 		},
 		"142": {
-			"sourceFileName": "src/common/enums/NeonSize.ts",
-			"qualifiedName": "NeonSize"
+			"sourceFileName": "src/common/enums/NeonResponsive.ts",
+			"qualifiedName": "NeonResponsive.MobileLarge"
 		},
 		"143": {
-			"sourceFileName": "src/common/enums/NeonSize.ts",
-			"qualifiedName": "NeonSize.Small"
+			"sourceFileName": "src/common/enums/NeonResponsive.ts",
+			"qualifiedName": "NeonResponsive.LargerThanMobile"
 		},
 		"144": {
-			"sourceFileName": "src/common/enums/NeonSize.ts",
-			"qualifiedName": "NeonSize.Medium"
+			"sourceFileName": "src/common/enums/NeonResponsive.ts",
+			"qualifiedName": "NeonResponsive.Mobile"
 		},
 		"145": {
 			"sourceFileName": "src/common/enums/NeonSize.ts",
-			"qualifiedName": "NeonSize.Large"
-		},
-		"146": {
-			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
 			"qualifiedName": ""
 		},
+		"146": {
+			"sourceFileName": "src/common/enums/NeonSize.ts",
+			"qualifiedName": "NeonSize"
+		},
 		"147": {
-			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
-			"qualifiedName": "NeonSplashLoaderSize"
+			"sourceFileName": "src/common/enums/NeonSize.ts",
+			"qualifiedName": "NeonSize.Small"
 		},
 		"148": {
-			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
-			"qualifiedName": "NeonSplashLoaderSize.Small"
+			"sourceFileName": "src/common/enums/NeonSize.ts",
+			"qualifiedName": "NeonSize.Medium"
 		},
 		"149": {
-			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
-			"qualifiedName": "NeonSplashLoaderSize.Medium"
+			"sourceFileName": "src/common/enums/NeonSize.ts",
+			"qualifiedName": "NeonSize.Large"
 		},
 		"150": {
 			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
-			"qualifiedName": "NeonSplashLoaderSize.Large"
+			"qualifiedName": ""
 		},
 		"151": {
 			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
-			"qualifiedName": "NeonSplashLoaderSize.ExtraLarge"
+			"qualifiedName": "NeonSplashLoaderSize"
 		},
 		"152": {
-			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
+			"qualifiedName": "NeonSplashLoaderSize.Small"
 		},
 		"153": {
-			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": "NeonState"
+			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
+			"qualifiedName": "NeonSplashLoaderSize.Medium"
 		},
 		"154": {
-			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": "NeonState.Ready"
+			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
+			"qualifiedName": "NeonSplashLoaderSize.Large"
 		},
 		"155": {
-			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": "NeonState.Loading"
+			"sourceFileName": "src/common/enums/NeonSplashLoaderSize.ts",
+			"qualifiedName": "NeonSplashLoaderSize.ExtraLarge"
 		},
 		"156": {
 			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": "NeonState.Success"
+			"qualifiedName": ""
 		},
 		"157": {
 			"sourceFileName": "src/common/enums/NeonState.ts",
-			"qualifiedName": "NeonState.Error"
+			"qualifiedName": "NeonState"
 		},
 		"158": {
-			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonState.ts",
+			"qualifiedName": "NeonState.Ready"
 		},
 		"159": {
-			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
-			"qualifiedName": "NeonSwitchStyle"
+			"sourceFileName": "src/common/enums/NeonState.ts",
+			"qualifiedName": "NeonState.Loading"
 		},
 		"160": {
-			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
-			"qualifiedName": "NeonSwitchStyle.Switch"
+			"sourceFileName": "src/common/enums/NeonState.ts",
+			"qualifiedName": "NeonState.Success"
 		},
 		"161": {
-			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
-			"qualifiedName": "NeonSwitchStyle.Checkbox"
+			"sourceFileName": "src/common/enums/NeonState.ts",
+			"qualifiedName": "NeonState.Error"
 		},
 		"162": {
-			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
+			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
 			"qualifiedName": ""
 		},
 		"163": {
-			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
-			"qualifiedName": "NeonToggleChipSize"
+			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
+			"qualifiedName": "NeonSwitchStyle"
 		},
 		"164": {
-			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
-			"qualifiedName": "NeonToggleChipSize.ExtraSmall"
+			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
+			"qualifiedName": "NeonSwitchStyle.Switch"
 		},
 		"165": {
-			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
-			"qualifiedName": "NeonToggleChipSize.Small"
+			"sourceFileName": "src/common/enums/NeonSwitchStyle.ts",
+			"qualifiedName": "NeonSwitchStyle.Checkbox"
 		},
 		"166": {
 			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
-			"qualifiedName": "NeonToggleChipSize.Medium"
+			"qualifiedName": ""
 		},
 		"167": {
 			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
-			"qualifiedName": "NeonToggleChipSize.Large"
+			"qualifiedName": "NeonToggleChipSize"
 		},
 		"168": {
-			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
+			"qualifiedName": "NeonToggleChipSize.ExtraSmall"
 		},
 		"169": {
-			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
-			"qualifiedName": "NeonToggleStyle"
+			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
+			"qualifiedName": "NeonToggleChipSize.Small"
 		},
 		"170": {
-			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
-			"qualifiedName": "NeonToggleStyle.Toggle"
+			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
+			"qualifiedName": "NeonToggleChipSize.Medium"
 		},
 		"171": {
-			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
-			"qualifiedName": "NeonToggleStyle.RadioButtons"
+			"sourceFileName": "src/common/enums/NeonToggleChipSize.ts",
+			"qualifiedName": "NeonToggleChipSize.Large"
 		},
 		"172": {
 			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
-			"qualifiedName": "NeonToggleStyle.Card"
-		},
-		"173": {
-			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
 			"qualifiedName": ""
 		},
+		"173": {
+			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
+			"qualifiedName": "NeonToggleStyle"
+		},
 		"174": {
-			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
-			"qualifiedName": "NeonTooltipStyle"
+			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
+			"qualifiedName": "NeonToggleStyle.Toggle"
 		},
 		"175": {
-			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
-			"qualifiedName": "NeonTooltipStyle.Tooltip"
+			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
+			"qualifiedName": "NeonToggleStyle.RadioButtons"
 		},
 		"176": {
-			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
-			"qualifiedName": "NeonTooltipStyle.Popover"
+			"sourceFileName": "src/common/enums/NeonToggleStyle.ts",
+			"qualifiedName": "NeonToggleStyle.Card"
 		},
 		"177": {
-			"sourceFileName": "src/common/enums/NeonVerticalPosition.ts",
+			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
 			"qualifiedName": ""
 		},
 		"178": {
+			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
+			"qualifiedName": "NeonTooltipStyle"
+		},
+		"179": {
+			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
+			"qualifiedName": "NeonTooltipStyle.Tooltip"
+		},
+		"180": {
+			"sourceFileName": "src/common/enums/NeonTooltipStyle.ts",
+			"qualifiedName": "NeonTooltipStyle.Popover"
+		},
+		"181": {
+			"sourceFileName": "src/common/enums/NeonVerticalPosition.ts",
+			"qualifiedName": ""
+		},
+		"182": {
 			"sourceFileName": "src/common/enums/NeonVerticalPosition.ts",
 			"qualifiedName": "NeonVerticalPosition"
 		},
-		"179": {
+		"183": {
 			"sourceFileName": "src/common/enums/NeonVerticalPosition.ts",
 			"qualifiedName": "NeonVerticalPosition.Top"
 		},
-		"180": {
+		"184": {
 			"sourceFileName": "src/common/enums/NeonVerticalPosition.ts",
 			"qualifiedName": "NeonVerticalPosition.Bottom"
 		}

--- a/src/app/config/models.json
+++ b/src/app/config/models.json
@@ -48,7 +48,7 @@
 									"fileName": "NeonActionMenuModel.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L13"
 								}
 							],
 							"type": {
@@ -77,7 +77,7 @@
 									"fileName": "NeonActionMenuModel.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L17"
 								}
 							],
 							"type": {
@@ -104,7 +104,7 @@
 									"fileName": "NeonActionMenuModel.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L8"
 								}
 							],
 							"type": {
@@ -131,7 +131,7 @@
 									"fileName": "NeonActionMenuModel.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L6"
 								}
 							],
 							"type": {
@@ -160,7 +160,7 @@
 									"fileName": "NeonActionMenuModel.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L15"
 								}
 							],
 							"type": {
@@ -186,7 +186,7 @@
 							"fileName": "NeonActionMenuModel.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L4"
 						}
 					]
 				}
@@ -204,7 +204,7 @@
 					"fileName": "NeonActionMenuModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonActionMenuModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonActionMenuModel.ts#L1"
 				}
 			]
 		},
@@ -241,7 +241,7 @@
 									"fileName": "NeonAlertAction.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L14"
 								}
 							],
 							"type": {
@@ -257,7 +257,7 @@
 											"fileName": "NeonAlertAction.ts",
 											"line": 14,
 											"character": 12,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L14"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L14"
 										}
 									],
 									"signatures": [
@@ -280,7 +280,7 @@
 													"fileName": "NeonAlertAction.ts",
 													"line": 14,
 													"character": 12,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L14"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L14"
 												}
 											],
 											"type": {
@@ -311,7 +311,7 @@
 									"fileName": "NeonAlertAction.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L9"
 								}
 							],
 							"type": {
@@ -334,7 +334,7 @@
 							"fileName": "NeonAlertAction.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L5"
 						}
 					]
 				}
@@ -352,7 +352,7 @@
 					"fileName": "NeonAlertAction.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertAction.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertAction.ts#L1"
 				}
 			]
 		},
@@ -399,7 +399,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 32,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L32"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L32"
 								}
 							],
 							"type": {
@@ -428,7 +428,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L27"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L27"
 								}
 							],
 							"type": {
@@ -457,7 +457,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L16"
 								}
 							],
 							"type": {
@@ -486,7 +486,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L21"
 								}
 							],
 							"type": {
@@ -520,7 +520,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L39"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L39"
 								}
 							],
 							"type": {
@@ -551,7 +551,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 44,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L44"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L44"
 								}
 							],
 							"type": {
@@ -582,7 +582,7 @@
 									"fileName": "NeonAlertMessage.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L11"
 								}
 							],
 							"type": {
@@ -610,7 +610,7 @@
 							"fileName": "NeonAlertMessage.ts",
 							"line": 7,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L7"
 						}
 					]
 				}
@@ -628,7 +628,7 @@
 					"fileName": "NeonAlertMessage.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAlertMessage.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAlertMessage.ts#L1"
 				}
 			]
 		},
@@ -658,7 +658,7 @@
 							"fileName": "NeonAvailableSpace.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L7"
 						}
 					],
 					"type": {
@@ -709,7 +709,7 @@
 													"fileName": "NeonAvailableSpace.ts",
 													"line": 11,
 													"character": 2,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L11"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L11"
 												}
 											],
 											"type": {
@@ -736,7 +736,7 @@
 													"fileName": "NeonAvailableSpace.ts",
 													"line": 13,
 													"character": 2,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L13"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L13"
 												}
 											],
 											"type": {
@@ -763,7 +763,7 @@
 													"fileName": "NeonAvailableSpace.ts",
 													"line": 15,
 													"character": 2,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L15"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L15"
 												}
 											],
 											"type": {
@@ -790,7 +790,7 @@
 													"fileName": "NeonAvailableSpace.ts",
 													"line": 9,
 													"character": 2,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L9"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L9"
 												}
 											],
 											"type": {
@@ -815,7 +815,7 @@
 											"fileName": "NeonAvailableSpace.ts",
 											"line": 7,
 											"character": 69,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L7"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L7"
 										}
 									]
 								}
@@ -837,7 +837,7 @@
 					"fileName": "NeonAvailableSpace.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonAvailableSpace.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonAvailableSpace.ts#L1"
 				}
 			]
 		},
@@ -882,7 +882,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L48"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L48"
 								}
 							],
 							"type": {
@@ -924,7 +924,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 32,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L32"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L32"
 								}
 							],
 							"type": {
@@ -954,7 +954,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L27"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L27"
 								}
 							],
 							"type": {
@@ -984,7 +984,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 50,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L50"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L50"
 								}
 							],
 							"type": {
@@ -1011,7 +1011,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L60"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L60"
 								}
 							],
 							"type": {
@@ -1041,7 +1041,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L55"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L55"
 								}
 							],
 							"type": {
@@ -1071,7 +1071,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L22"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L22"
 								}
 							],
 							"type": {
@@ -1098,7 +1098,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L13"
 								}
 							],
 							"type": {
@@ -1125,7 +1125,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L18"
 								}
 							],
 							"type": {
@@ -1152,7 +1152,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L20"
 								}
 							],
 							"type": {
@@ -1181,7 +1181,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L11"
 								}
 							],
 							"type": {
@@ -1210,7 +1210,7 @@
 									"fileName": "NeonCalendarConfig.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L9"
 								}
 							],
 							"type": {
@@ -1245,7 +1245,7 @@
 							"fileName": "NeonCalendarConfig.ts",
 							"line": 7,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L7"
 						}
 					]
 				}
@@ -1263,7 +1263,7 @@
 					"fileName": "NeonCalendarConfig.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCalendarConfig.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCalendarConfig.ts#L1"
 				}
 			]
 		},
@@ -1310,7 +1310,7 @@
 									"fileName": "NeonCardListModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L21"
 								}
 							],
 							"type": {
@@ -1339,7 +1339,7 @@
 									"fileName": "NeonCardListModel.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L13"
 								}
 							],
 							"type": {
@@ -1368,7 +1368,7 @@
 									"fileName": "NeonCardListModel.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L9"
 								}
 							],
 							"type": {
@@ -1397,7 +1397,7 @@
 									"fileName": "NeonCardListModel.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L17"
 								}
 							],
 							"type": {
@@ -1422,7 +1422,7 @@
 							"fileName": "NeonCardListModel.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L5"
 						}
 					]
 				}
@@ -1440,7 +1440,7 @@
 					"fileName": "NeonCardListModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCardListModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCardListModel.ts#L1"
 				}
 			]
 		},
@@ -1487,7 +1487,7 @@
 									"fileName": "NeonCarouselImage.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCarouselImage.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCarouselImage.ts#L13"
 								}
 							],
 							"type": {
@@ -1514,7 +1514,7 @@
 									"fileName": "NeonCarouselImage.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCarouselImage.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCarouselImage.ts#L9"
 								}
 							],
 							"type": {
@@ -1537,7 +1537,7 @@
 							"fileName": "NeonCarouselImage.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCarouselImage.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCarouselImage.ts#L5"
 						}
 					]
 				}
@@ -1555,7 +1555,7 @@
 					"fileName": "NeonCarouselImage.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonCarouselImage.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonCarouselImage.ts#L1"
 				}
 			]
 		},
@@ -1600,7 +1600,7 @@
 									"fileName": "NeonContrastAccessibility.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L11"
 								}
 							],
 							"type": {
@@ -1627,7 +1627,7 @@
 									"fileName": "NeonContrastAccessibility.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L13"
 								}
 							],
 							"type": {
@@ -1654,7 +1654,7 @@
 									"fileName": "NeonContrastAccessibility.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L7"
 								}
 							],
 							"type": {
@@ -1681,7 +1681,7 @@
 									"fileName": "NeonContrastAccessibility.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L9"
 								}
 							],
 							"type": {
@@ -1708,7 +1708,7 @@
 									"fileName": "NeonContrastAccessibility.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L17"
 								}
 							],
 							"type": {
@@ -1734,7 +1734,7 @@
 							"fileName": "NeonContrastAccessibility.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L5"
 						}
 					]
 				}
@@ -1752,7 +1752,7 @@
 					"fileName": "NeonContrastAccessibility.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonContrastAccessibility.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonContrastAccessibility.ts#L1"
 				}
 			]
 		},
@@ -1797,7 +1797,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L17"
 								}
 							],
 							"type": {
@@ -1824,7 +1824,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L19"
 								}
 							],
 							"type": {
@@ -1851,7 +1851,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L11"
 								}
 							],
 							"type": {
@@ -1878,7 +1878,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L15"
 								}
 							],
 							"type": {
@@ -1905,7 +1905,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L13"
 								}
 							],
 							"type": {
@@ -1934,7 +1934,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L21"
 								}
 							],
 							"type": {
@@ -1963,7 +1963,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L23"
 								}
 							],
 							"type": {
@@ -1990,7 +1990,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L7"
 								}
 							],
 							"type": {
@@ -2017,7 +2017,7 @@
 									"fileName": "NeonDate.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L9"
 								}
 							],
 							"type": {
@@ -2047,7 +2047,7 @@
 							"fileName": "NeonDate.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L5"
 						}
 					]
 				}
@@ -2065,7 +2065,7 @@
 					"fileName": "NeonDate.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDate.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDate.ts#L1"
 				}
 			]
 		},
@@ -2112,7 +2112,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L16"
 								}
 							],
 							"type": {
@@ -2141,7 +2141,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L23"
 								}
 							],
 							"type": {
@@ -2170,7 +2170,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L10"
 								}
 							],
 							"type": {
@@ -2199,7 +2199,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L12"
 								}
 							],
 							"type": {
@@ -2228,7 +2228,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L21"
 								}
 							],
 							"type": {
@@ -2255,7 +2255,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L6"
 								}
 							],
 							"type": {
@@ -2282,7 +2282,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L8"
 								}
 							],
 							"type": {
@@ -2311,7 +2311,7 @@
 									"fileName": "NeonDropdownMenuItem.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L14"
 								}
 							],
 							"type": {
@@ -2340,7 +2340,7 @@
 							"fileName": "NeonDropdownMenuItem.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L4"
 						}
 					]
 				}
@@ -2358,7 +2358,7 @@
 					"fileName": "NeonDropdownMenuItem.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownMenuItem.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownMenuItem.ts#L1"
 				}
 			]
 		},
@@ -2373,7 +2373,7 @@
 					"fileName": "NeonDropdownPlacementObject.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonDropdownPlacementObject.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonDropdownPlacementObject.ts#L1"
 				}
 			]
 		},
@@ -2418,7 +2418,7 @@
 									"fileName": "NeonFilterListItem.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L10"
 								}
 							],
 							"type": {
@@ -2447,7 +2447,7 @@
 									"fileName": "NeonFilterListItem.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L12"
 								}
 							],
 							"type": {
@@ -2474,7 +2474,7 @@
 									"fileName": "NeonFilterListItem.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L6"
 								}
 							],
 							"type": {
@@ -2501,7 +2501,7 @@
 									"fileName": "NeonFilterListItem.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L8"
 								}
 							],
 							"type": {
@@ -2526,7 +2526,7 @@
 							"fileName": "NeonFilterListItem.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L4"
 						}
 					]
 				}
@@ -2544,7 +2544,7 @@
 					"fileName": "NeonFilterListItem.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonFilterListItem.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonFilterListItem.ts#L1"
 				}
 			]
 		},
@@ -2589,7 +2589,7 @@
 									"fileName": "NeonGridModel.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonGridModel.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonGridModel.ts#L10"
 								}
 							],
 							"type": {
@@ -2621,7 +2621,7 @@
 									"fileName": "NeonGridModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonGridModel.ts#L26"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonGridModel.ts#L26"
 								}
 							],
 							"type": {
@@ -2650,7 +2650,7 @@
 							"fileName": "NeonGridModel.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonGridModel.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonGridModel.ts#L6"
 						}
 					]
 				}
@@ -2668,7 +2668,7 @@
 					"fileName": "NeonGridModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonGridModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonGridModel.ts#L1"
 				}
 			]
 		},
@@ -2713,7 +2713,7 @@
 									"fileName": "NeonListItem.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonListItem.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonListItem.ts#L6"
 								}
 							],
 							"type": {
@@ -2740,7 +2740,7 @@
 									"fileName": "NeonListItem.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonListItem.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonListItem.ts#L8"
 								}
 							],
 							"type": {
@@ -2763,7 +2763,7 @@
 							"fileName": "NeonListItem.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonListItem.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonListItem.ts#L4"
 						}
 					]
 				}
@@ -2781,7 +2781,7 @@
 					"fileName": "NeonListItem.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonListItem.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonListItem.ts#L1"
 				}
 			]
 		},
@@ -2828,7 +2828,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L14"
 								}
 							],
 							"type": {
@@ -2857,7 +2857,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L10"
 								}
 							],
 							"type": {
@@ -2886,7 +2886,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L12"
 								}
 							],
 							"type": {
@@ -2913,7 +2913,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L6"
 								}
 							],
 							"type": {
@@ -2942,7 +2942,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L8"
 								}
 							],
 							"type": {
@@ -2968,7 +2968,7 @@
 							"fileName": "NeonMenuItem.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L4"
 						}
 					],
 					"extendedBy": [
@@ -2993,7 +2993,7 @@
 					"fileName": "NeonMenuItem.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L1"
 				}
 			]
 		},
@@ -3040,7 +3040,7 @@
 									"fileName": "NeonMenuModel.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuModel.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuModel.ts#L8"
 								}
 							],
 							"type": {
@@ -3074,7 +3074,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L14"
 								}
 							],
 							"type": {
@@ -3108,7 +3108,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L10"
 								}
 							],
 							"type": {
@@ -3142,7 +3142,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L12"
 								}
 							],
 							"type": {
@@ -3174,7 +3174,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L6"
 								}
 							],
 							"type": {
@@ -3208,7 +3208,7 @@
 									"fileName": "NeonMenuItem.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuItem.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuItem.ts#L8"
 								}
 							],
 							"type": {
@@ -3240,7 +3240,7 @@
 							"fileName": "NeonMenuModel.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuModel.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuModel.ts#L6"
 						}
 					],
 					"extendedTypes": [
@@ -3266,7 +3266,7 @@
 					"fileName": "NeonMenuModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonMenuModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonMenuModel.ts#L1"
 				}
 			]
 		},
@@ -3313,7 +3313,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L22"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L22"
 								}
 							],
 							"type": {
@@ -3342,7 +3342,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L7"
 								}
 							],
 							"type": {
@@ -3371,7 +3371,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L12"
 								}
 							],
 							"type": {
@@ -3400,7 +3400,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L16"
 								}
 							],
 							"type": {
@@ -3429,7 +3429,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L14"
 								}
 							],
 							"type": {
@@ -3458,7 +3458,7 @@
 									"fileName": "NeonNumberFormatOptions.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L20"
 								}
 							],
 							"type": {
@@ -3485,7 +3485,7 @@
 							"fileName": "NeonNumberFormatOptions.ts",
 							"line": 5,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L5"
 						}
 					]
 				}
@@ -3503,7 +3503,7 @@
 					"fileName": "NeonNumberFormatOptions.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonNumberFormatOptions.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonNumberFormatOptions.ts#L1"
 				}
 			]
 		},
@@ -3550,7 +3550,7 @@
 									"fileName": "NeonSearchOption.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L17"
 								}
 							],
 							"type": {
@@ -3584,7 +3584,7 @@
 									"fileName": "NeonSearchOption.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L19"
 								}
 							],
 							"type": {
@@ -3611,7 +3611,7 @@
 									"fileName": "NeonSearchOption.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L13"
 								}
 							],
 							"type": {
@@ -3638,7 +3638,7 @@
 									"fileName": "NeonSearchOption.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L15"
 								}
 							],
 							"type": {
@@ -3667,7 +3667,7 @@
 									"fileName": "NeonSearchOption.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L21"
 								}
 							],
 							"type": {
@@ -3693,7 +3693,7 @@
 							"fileName": "NeonSearchOption.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L6"
 						}
 					]
 				}
@@ -3711,7 +3711,7 @@
 					"fileName": "NeonSearchOption.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSearchOption.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSearchOption.ts#L1"
 				}
 			]
 		},
@@ -3756,7 +3756,7 @@
 									"fileName": "NeonSelectGroup.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectGroup.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectGroup.ts#L8"
 								}
 							],
 							"type": {
@@ -3783,7 +3783,7 @@
 									"fileName": "NeonSelectGroup.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectGroup.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectGroup.ts#L10"
 								}
 							],
 							"type": {
@@ -3811,7 +3811,7 @@
 							"fileName": "NeonSelectGroup.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectGroup.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectGroup.ts#L6"
 						}
 					]
 				}
@@ -3829,7 +3829,7 @@
 					"fileName": "NeonSelectGroup.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectGroup.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectGroup.ts#L1"
 				}
 			]
 		},
@@ -3876,7 +3876,7 @@
 									"fileName": "NeonSelectOption.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L19"
 								}
 							],
 							"type": {
@@ -3905,7 +3905,7 @@
 									"fileName": "NeonSelectOption.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L15"
 								}
 							],
 							"type": {
@@ -3932,7 +3932,7 @@
 									"fileName": "NeonSelectOption.ts",
 									"line": 11,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L11"
 								}
 							],
 							"type": {
@@ -3959,7 +3959,7 @@
 									"fileName": "NeonSelectOption.ts",
 									"line": 13,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L13"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L13"
 								}
 							],
 							"type": {
@@ -3988,7 +3988,7 @@
 									"fileName": "NeonSelectOption.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L17"
 								}
 							],
 							"type": {
@@ -4014,7 +4014,7 @@
 							"fileName": "NeonSelectOption.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L4"
 						}
 					]
 				}
@@ -4032,7 +4032,7 @@
 					"fileName": "NeonSelectOption.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonSelectOption.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonSelectOption.ts#L1"
 				}
 			]
 		},
@@ -4060,6 +4060,35 @@
 					"children": [
 						{
 							"id": 201,
+							"name": "href",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "URL of the tab."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "NeonTabModel.ts",
+									"line": 16,
+									"character": 2,
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L16"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 202,
 							"name": "icon",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4077,9 +4106,9 @@
 							"sources": [
 								{
 									"fileName": "NeonTabModel.ts",
-									"line": 16,
+									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTabModel.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L18"
 								}
 							],
 							"type": {
@@ -4106,7 +4135,7 @@
 									"fileName": "NeonTabModel.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTabModel.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L14"
 								}
 							],
 							"type": {
@@ -4133,7 +4162,7 @@
 									"fileName": "NeonTabModel.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTabModel.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L6"
 								}
 							],
 							"type": {
@@ -4147,6 +4176,7 @@
 							"title": "Properties",
 							"children": [
 								201,
+								202,
 								200,
 								199
 							]
@@ -4157,7 +4187,7 @@
 							"fileName": "NeonTabModel.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTabModel.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L4"
 						}
 					]
 				}
@@ -4175,19 +4205,19 @@
 					"fileName": "NeonTabModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTabModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTabModel.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 202,
+			"id": 203,
 			"name": "NeonToastMessage",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 203,
+					"id": 204,
 					"name": "NeonToastMessage",
 					"variant": "declaration",
 					"kind": 256,
@@ -4202,7 +4232,7 @@
 					},
 					"children": [
 						{
-							"id": 207,
+							"id": 208,
 							"name": "dismissible",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4222,7 +4252,7 @@
 									"fileName": "NeonToastMessage.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L26"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L26"
 								}
 							],
 							"type": {
@@ -4231,7 +4261,7 @@
 							}
 						},
 						{
-							"id": 206,
+							"id": 207,
 							"name": "duration",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4251,7 +4281,7 @@
 									"fileName": "NeonToastMessage.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L21"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L21"
 								}
 							],
 							"type": {
@@ -4260,7 +4290,7 @@
 							}
 						},
 						{
-							"id": 205,
+							"id": 206,
 							"name": "placement",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4280,7 +4310,7 @@
 									"fileName": "NeonToastMessage.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L15"
 								}
 							],
 							"type": {
@@ -4294,7 +4324,7 @@
 							}
 						},
 						{
-							"id": 204,
+							"id": 205,
 							"name": "title",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4312,7 +4342,7 @@
 									"fileName": "NeonToastMessage.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L10"
 								}
 							],
 							"type": {
@@ -4325,10 +4355,10 @@
 						{
 							"title": "Properties",
 							"children": [
+								208,
 								207,
 								206,
-								205,
-								204
+								205
 							]
 						}
 					],
@@ -4337,7 +4367,7 @@
 							"fileName": "NeonToastMessage.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L6"
 						}
 					]
 				}
@@ -4346,7 +4376,7 @@
 				{
 					"title": "Interfaces",
 					"children": [
-						203
+						204
 					]
 				}
 			],
@@ -4355,19 +4385,19 @@
 					"fileName": "NeonToastMessage.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToastMessage.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToastMessage.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 208,
+			"id": 209,
 			"name": "NeonToggleModel",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 209,
+					"id": 210,
 					"name": "NeonToggleModel",
 					"variant": "declaration",
 					"kind": 256,
@@ -4382,7 +4412,7 @@
 					},
 					"children": [
 						{
-							"id": 213,
+							"id": 214,
 							"name": "disabled",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4402,7 +4432,7 @@
 									"fileName": "NeonToggleModel.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L12"
 								}
 							],
 							"type": {
@@ -4411,7 +4441,7 @@
 							}
 						},
 						{
-							"id": 212,
+							"id": 213,
 							"name": "icon",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4431,7 +4461,7 @@
 									"fileName": "NeonToggleModel.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L10"
 								}
 							],
 							"type": {
@@ -4440,7 +4470,7 @@
 							}
 						},
 						{
-							"id": 210,
+							"id": 211,
 							"name": "key",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4458,7 +4488,7 @@
 									"fileName": "NeonToggleModel.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L6"
 								}
 							],
 							"type": {
@@ -4467,7 +4497,7 @@
 							}
 						},
 						{
-							"id": 211,
+							"id": 212,
 							"name": "label",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4487,7 +4517,7 @@
 									"fileName": "NeonToggleModel.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L8"
 								}
 							],
 							"type": {
@@ -4500,10 +4530,10 @@
 						{
 							"title": "Properties",
 							"children": [
+								214,
 								213,
-								212,
-								210,
-								211
+								211,
+								212
 							]
 						}
 					],
@@ -4512,7 +4542,7 @@
 							"fileName": "NeonToggleModel.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L4"
 						}
 					]
 				}
@@ -4521,7 +4551,7 @@
 				{
 					"title": "Interfaces",
 					"children": [
-						209
+						210
 					]
 				}
 			],
@@ -4530,19 +4560,19 @@
 					"fileName": "NeonToggleModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonToggleModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonToggleModel.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 214,
+			"id": 215,
 			"name": "NeonTreeMenuLinkModel",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 215,
+					"id": 216,
 					"name": "NeonTreeMenuLinkModel",
 					"variant": "declaration",
 					"kind": 256,
@@ -4557,7 +4587,7 @@
 					},
 					"children": [
 						{
-							"id": 219,
+							"id": 220,
 							"name": "anchors",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4577,7 +4607,7 @@
 									"fileName": "NeonTreeMenuLinkModel.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L12"
 								}
 							],
 							"type": {
@@ -4589,7 +4619,7 @@
 							}
 						},
 						{
-							"id": 218,
+							"id": 219,
 							"name": "href",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4609,7 +4639,7 @@
 									"fileName": "NeonTreeMenuLinkModel.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L10"
 								}
 							],
 							"type": {
@@ -4618,7 +4648,7 @@
 							}
 						},
 						{
-							"id": 217,
+							"id": 218,
 							"name": "key",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4636,7 +4666,7 @@
 									"fileName": "NeonTreeMenuLinkModel.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L8"
 								}
 							],
 							"type": {
@@ -4645,7 +4675,7 @@
 							}
 						},
 						{
-							"id": 216,
+							"id": 217,
 							"name": "label",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4663,7 +4693,7 @@
 									"fileName": "NeonTreeMenuLinkModel.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L6"
 								}
 							],
 							"type": {
@@ -4676,10 +4706,10 @@
 						{
 							"title": "Properties",
 							"children": [
+								220,
 								219,
 								218,
-								217,
-								216
+								217
 							]
 						}
 					],
@@ -4688,7 +4718,7 @@
 							"fileName": "NeonTreeMenuLinkModel.ts",
 							"line": 4,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L4"
 						}
 					]
 				}
@@ -4697,7 +4727,7 @@
 				{
 					"title": "Interfaces",
 					"children": [
-						215
+						216
 					]
 				}
 			],
@@ -4706,19 +4736,19 @@
 					"fileName": "NeonTreeMenuLinkModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuLinkModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuLinkModel.ts#L1"
 				}
 			]
 		},
 		{
-			"id": 220,
+			"id": 221,
 			"name": "NeonTreeMenuSectionModel",
 			"variant": "declaration",
 			"kind": 2,
 			"flags": {},
 			"children": [
 				{
-					"id": 221,
+					"id": 222,
 					"name": "NeonTreeMenuSectionModel",
 					"variant": "declaration",
 					"kind": 256,
@@ -4733,7 +4763,7 @@
 					},
 					"children": [
 						{
-							"id": 225,
+							"id": 226,
 							"name": "children",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4753,21 +4783,21 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 14,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L14"
 								}
 							],
 							"type": {
 								"type": "array",
 								"elementType": {
 									"type": "reference",
-									"target": 215,
+									"target": 216,
 									"name": "NeonTreeMenuLinkModel",
 									"package": "@aotearoan/neon"
 								}
 							}
 						},
 						{
-							"id": 227,
+							"id": 228,
 							"name": "disabled",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4787,7 +4817,7 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L18"
 								}
 							],
 							"type": {
@@ -4796,7 +4826,7 @@
 							}
 						},
 						{
-							"id": 226,
+							"id": 227,
 							"name": "expanded",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4816,7 +4846,7 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 16,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L16"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L16"
 								}
 							],
 							"type": {
@@ -4825,7 +4855,7 @@
 							}
 						},
 						{
-							"id": 224,
+							"id": 225,
 							"name": "href",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4845,7 +4875,7 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 12,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L12"
 								}
 							],
 							"type": {
@@ -4854,7 +4884,7 @@
 							}
 						},
 						{
-							"id": 223,
+							"id": 224,
 							"name": "key",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4872,7 +4902,7 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L10"
 								}
 							],
 							"type": {
@@ -4881,7 +4911,7 @@
 							}
 						},
 						{
-							"id": 222,
+							"id": 223,
 							"name": "label",
 							"variant": "declaration",
 							"kind": 1024,
@@ -4899,7 +4929,7 @@
 									"fileName": "NeonTreeMenuSectionModel.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L8"
 								}
 							],
 							"type": {
@@ -4912,12 +4942,12 @@
 						{
 							"title": "Properties",
 							"children": [
-								225,
-								227,
 								226,
+								228,
+								227,
+								225,
 								224,
-								223,
-								222
+								223
 							]
 						}
 					],
@@ -4926,7 +4956,7 @@
 							"fileName": "NeonTreeMenuSectionModel.ts",
 							"line": 6,
 							"character": 17,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L6"
 						}
 					]
 				}
@@ -4935,7 +4965,7 @@
 				{
 					"title": "Interfaces",
 					"children": [
-						221
+						222
 					]
 				}
 			],
@@ -4944,7 +4974,7 @@
 					"fileName": "NeonTreeMenuSectionModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/models/NeonTreeMenuSectionModel.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/models/NeonTreeMenuSectionModel.ts#L1"
 				}
 			]
 		}
@@ -4974,10 +5004,10 @@
 				186,
 				190,
 				197,
-				202,
-				208,
-				214,
-				220
+				203,
+				209,
+				215,
+				221
 			]
 		}
 	],
@@ -5555,109 +5585,113 @@
 		},
 		"201": {
 			"sourceFileName": "src/common/models/NeonTabModel.ts",
-			"qualifiedName": "NeonTabModel.icon"
+			"qualifiedName": "NeonTabModel.href"
 		},
 		"202": {
-			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/models/NeonTabModel.ts",
+			"qualifiedName": "NeonTabModel.icon"
 		},
 		"203": {
 			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": "NeonToastMessage"
+			"qualifiedName": ""
 		},
 		"204": {
 			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": "NeonToastMessage.title"
+			"qualifiedName": "NeonToastMessage"
 		},
 		"205": {
 			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": "NeonToastMessage.placement"
+			"qualifiedName": "NeonToastMessage.title"
 		},
 		"206": {
 			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": "NeonToastMessage.duration"
+			"qualifiedName": "NeonToastMessage.placement"
 		},
 		"207": {
 			"sourceFileName": "src/common/models/NeonToastMessage.ts",
-			"qualifiedName": "NeonToastMessage.dismissible"
+			"qualifiedName": "NeonToastMessage.duration"
 		},
 		"208": {
-			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/models/NeonToastMessage.ts",
+			"qualifiedName": "NeonToastMessage.dismissible"
 		},
 		"209": {
 			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": "NeonToggleModel"
+			"qualifiedName": ""
 		},
 		"210": {
 			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": "NeonToggleModel.key"
+			"qualifiedName": "NeonToggleModel"
 		},
 		"211": {
 			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": "NeonToggleModel.label"
+			"qualifiedName": "NeonToggleModel.key"
 		},
 		"212": {
 			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": "NeonToggleModel.icon"
+			"qualifiedName": "NeonToggleModel.label"
 		},
 		"213": {
 			"sourceFileName": "src/common/models/NeonToggleModel.ts",
-			"qualifiedName": "NeonToggleModel.disabled"
+			"qualifiedName": "NeonToggleModel.icon"
 		},
 		"214": {
-			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/models/NeonToggleModel.ts",
+			"qualifiedName": "NeonToggleModel.disabled"
 		},
 		"215": {
 			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": "NeonTreeMenuLinkModel"
+			"qualifiedName": ""
 		},
 		"216": {
 			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": "NeonTreeMenuLinkModel.label"
+			"qualifiedName": "NeonTreeMenuLinkModel"
 		},
 		"217": {
 			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": "NeonTreeMenuLinkModel.key"
+			"qualifiedName": "NeonTreeMenuLinkModel.label"
 		},
 		"218": {
 			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": "NeonTreeMenuLinkModel.href"
+			"qualifiedName": "NeonTreeMenuLinkModel.key"
 		},
 		"219": {
 			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
-			"qualifiedName": "NeonTreeMenuLinkModel.anchors"
+			"qualifiedName": "NeonTreeMenuLinkModel.href"
 		},
 		"220": {
-			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": ""
+			"sourceFileName": "src/common/models/NeonTreeMenuLinkModel.ts",
+			"qualifiedName": "NeonTreeMenuLinkModel.anchors"
 		},
 		"221": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel"
+			"qualifiedName": ""
 		},
 		"222": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel.label"
+			"qualifiedName": "NeonTreeMenuSectionModel"
 		},
 		"223": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel.key"
+			"qualifiedName": "NeonTreeMenuSectionModel.label"
 		},
 		"224": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel.href"
+			"qualifiedName": "NeonTreeMenuSectionModel.key"
 		},
 		"225": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel.children"
+			"qualifiedName": "NeonTreeMenuSectionModel.href"
 		},
 		"226": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
-			"qualifiedName": "NeonTreeMenuSectionModel.expanded"
+			"qualifiedName": "NeonTreeMenuSectionModel.children"
 		},
 		"227": {
+			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
+			"qualifiedName": "NeonTreeMenuSectionModel.expanded"
+		},
+		"228": {
 			"sourceFileName": "src/common/models/NeonTreeMenuSectionModel.ts",
 			"qualifiedName": "NeonTreeMenuSectionModel.disabled"
 		}

--- a/src/app/config/utils.json
+++ b/src/app/config/utils.json
@@ -63,7 +63,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 56,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L56"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L56"
 								}
 							],
 							"signatures": [
@@ -78,7 +78,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 56,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L56"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L56"
 										}
 									],
 									"parameters": [
@@ -136,7 +136,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 41,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L41"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L41"
 								}
 							],
 							"signatures": [
@@ -159,7 +159,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 41,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L41"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L41"
 										}
 									],
 									"parameters": [
@@ -209,7 +209,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 52,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L52"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L52"
 								}
 							],
 							"signatures": [
@@ -243,7 +243,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 52,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L52"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L52"
 										}
 									],
 									"parameters": [
@@ -293,7 +293,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 14,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L14"
 								}
 							],
 							"signatures": [
@@ -316,7 +316,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 14,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L14"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L14"
 										}
 									],
 									"parameters": [
@@ -366,7 +366,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 23,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L23"
 								}
 							],
 							"signatures": [
@@ -389,7 +389,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 23,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L23"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L23"
 										}
 									],
 									"parameters": [
@@ -439,7 +439,7 @@
 									"fileName": "NeonAlertService.ts",
 									"line": 32,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L32"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L32"
 								}
 							],
 							"signatures": [
@@ -462,7 +462,7 @@
 											"fileName": "NeonAlertService.ts",
 											"line": 32,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L32"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L32"
 										}
 									],
 									"parameters": [
@@ -523,7 +523,7 @@
 							"fileName": "NeonAlertService.ts",
 							"line": 8,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L8"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L8"
 						}
 					]
 				}
@@ -541,7 +541,7 @@
 					"fileName": "NeonAlertService.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonAlertService.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonAlertService.ts#L1"
 				}
 			]
 		},
@@ -602,7 +602,7 @@
 									"fileName": "NeonClipboardService.ts",
 									"line": 12,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClipboardService.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClipboardService.ts#L12"
 								}
 							],
 							"signatures": [
@@ -636,7 +636,7 @@
 											"fileName": "NeonClipboardService.ts",
 											"line": 12,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClipboardService.ts#L12"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClipboardService.ts#L12"
 										}
 									],
 									"parameters": [
@@ -698,7 +698,7 @@
 							"fileName": "NeonClipboardService.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClipboardService.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClipboardService.ts#L4"
 						}
 					]
 				},
@@ -715,7 +715,7 @@
 							"fileName": "NeonClipboardService.ts",
 							"line": 17,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClipboardService.ts#L17"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClipboardService.ts#L17"
 						}
 					],
 					"type": {
@@ -746,7 +746,7 @@
 					"fileName": "NeonClipboardService.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClipboardService.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClipboardService.ts#L1"
 				}
 			]
 		},
@@ -785,7 +785,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L17"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L17"
 								}
 							],
 							"signatures": [
@@ -808,7 +808,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 17,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L17"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L17"
 										}
 									],
 									"parameters": [
@@ -863,7 +863,7 @@
 															"fileName": "NeonClosableUtils.ts",
 															"line": 17,
 															"character": 57,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L17"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L17"
 														}
 													],
 													"signatures": [
@@ -878,7 +878,7 @@
 																	"fileName": "NeonClosableUtils.ts",
 																	"line": 17,
 																	"character": 57,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L17"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L17"
 																}
 															],
 															"type": {
@@ -913,7 +913,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 8,
 									"character": 10,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L8"
 								}
 							],
 							"type": {
@@ -936,7 +936,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 7,
 									"character": 19,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L7"
 								}
 							],
 							"type": {
@@ -952,7 +952,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 7,
 											"character": 34,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L7"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L7"
 										}
 									],
 									"signatures": [
@@ -967,7 +967,7 @@
 													"fileName": "NeonClosableUtils.ts",
 													"line": 7,
 													"character": 34,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L7"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L7"
 												}
 											],
 											"type": {
@@ -993,7 +993,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 6,
 									"character": 19,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L6"
 								}
 							],
 							"type": {
@@ -1019,7 +1019,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 53,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L53"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L53"
 								}
 							],
 							"signatures": [
@@ -1042,7 +1042,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 53,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L53"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L53"
 										}
 									],
 									"type": {
@@ -1065,7 +1065,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 37,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L37"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L37"
 								}
 							],
 							"signatures": [
@@ -1088,7 +1088,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 37,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L37"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L37"
 										}
 									],
 									"type": {
@@ -1109,7 +1109,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L43"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L43"
 								}
 							],
 							"signatures": [
@@ -1124,7 +1124,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 43,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L43"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L43"
 										}
 									],
 									"parameters": [
@@ -1165,7 +1165,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 62,
 									"character": 10,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L62"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L62"
 								}
 							],
 							"signatures": [
@@ -1180,7 +1180,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 62,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L62"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L62"
 										}
 									],
 									"parameters": [
@@ -1235,7 +1235,7 @@
 									"fileName": "NeonClosableUtils.ts",
 									"line": 29,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L29"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L29"
 								}
 							],
 							"signatures": [
@@ -1258,7 +1258,7 @@
 											"fileName": "NeonClosableUtils.ts",
 											"line": 29,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L29"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L29"
 										}
 									],
 									"type": {
@@ -1300,7 +1300,7 @@
 							"fileName": "NeonClosableUtils.ts",
 							"line": 5,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L5"
 						}
 					]
 				}
@@ -1318,7 +1318,7 @@
 					"fileName": "NeonClosableUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonClosableUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonClosableUtils.ts#L1"
 				}
 			]
 		},
@@ -1333,7 +1333,7 @@
 					"fileName": "NeonColorUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonColorUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonColorUtils.ts#L1"
 				}
 			]
 		},
@@ -1395,7 +1395,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 64,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L64"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L64"
 								}
 							],
 							"signatures": [
@@ -1429,7 +1429,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 64,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L64"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L64"
 										}
 									],
 									"parameters": [
@@ -1499,7 +1499,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 78,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L78"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L78"
 								}
 							],
 							"signatures": [
@@ -1533,7 +1533,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 78,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L78"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L78"
 										}
 									],
 									"parameters": [
@@ -1616,7 +1616,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 90,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L90"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L90"
 								}
 							],
 							"signatures": [
@@ -1650,7 +1650,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 90,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L90"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L90"
 										}
 									],
 									"parameters": [
@@ -1733,7 +1733,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 116,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L116"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L116"
 								}
 							],
 							"signatures": [
@@ -1767,7 +1767,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 116,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L116"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L116"
 										}
 									],
 									"parameters": [
@@ -1858,7 +1858,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 18,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L18"
 								}
 							],
 							"signatures": [
@@ -1892,7 +1892,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 18,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L18"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L18"
 										}
 									],
 									"parameters": [
@@ -1983,7 +1983,7 @@
 									"fileName": "NeonDateUtils.ts",
 									"line": 140,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L140"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L140"
 								}
 							],
 							"signatures": [
@@ -2017,7 +2017,7 @@
 											"fileName": "NeonDateUtils.ts",
 											"line": 140,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L140"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L140"
 										}
 									],
 									"parameters": [
@@ -2164,7 +2164,7 @@
 							"fileName": "NeonDateUtils.ts",
 							"line": 8,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L8"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L8"
 						}
 					]
 				}
@@ -2182,7 +2182,7 @@
 					"fileName": "NeonDateUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDateUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDateUtils.ts#L1"
 				}
 			]
 		},
@@ -2244,7 +2244,7 @@
 									"fileName": "NeonDebounceUtils.ts",
 									"line": 6,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L6"
 								}
 							],
 							"type": {
@@ -2267,7 +2267,7 @@
 									"fileName": "NeonDebounceUtils.ts",
 									"line": 28,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 								}
 							],
 							"signatures": [
@@ -2301,7 +2301,7 @@
 											"fileName": "NeonDebounceUtils.ts",
 											"line": 28,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 										}
 									],
 									"parameters": [
@@ -2332,7 +2332,7 @@
 															"fileName": "NeonDebounceUtils.ts",
 															"line": 28,
 															"character": 29,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 														}
 													],
 													"signatures": [
@@ -2347,7 +2347,7 @@
 																	"fileName": "NeonDebounceUtils.ts",
 																	"line": 28,
 																	"character": 29,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 																}
 															],
 															"parameters": [
@@ -2411,7 +2411,7 @@
 													"fileName": "NeonDebounceUtils.ts",
 													"line": 28,
 													"character": 29,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 												}
 											],
 											"signatures": [
@@ -2426,7 +2426,7 @@
 															"fileName": "NeonDebounceUtils.ts",
 															"line": 28,
 															"character": 29,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L28"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L28"
 														}
 													],
 													"parameters": [
@@ -2472,7 +2472,7 @@
 									"fileName": "NeonDebounceUtils.ts",
 									"line": 14,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L14"
 								}
 							],
 							"signatures": [
@@ -2495,7 +2495,7 @@
 											"fileName": "NeonDebounceUtils.ts",
 											"line": 14,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L14"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L14"
 										}
 									],
 									"parameters": [
@@ -2553,7 +2553,7 @@
 							"fileName": "NeonDebounceUtils.ts",
 							"line": 5,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L5"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L5"
 						}
 					]
 				}
@@ -2571,7 +2571,7 @@
 					"fileName": "NeonDebounceUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDebounceUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDebounceUtils.ts#L1"
 				}
 			]
 		},
@@ -2633,7 +2633,7 @@
 									"fileName": "NeonDropdownPlacementUtils.ts",
 									"line": 24,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L24"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L24"
 								}
 							],
 							"signatures": [
@@ -2667,7 +2667,7 @@
 											"fileName": "NeonDropdownPlacementUtils.ts",
 											"line": 24,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L24"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L24"
 										}
 									],
 									"parameters": [
@@ -2796,7 +2796,7 @@
 									"fileName": "NeonDropdownPlacementUtils.ts",
 									"line": 58,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L58"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L58"
 								}
 							],
 							"signatures": [
@@ -2811,7 +2811,7 @@
 											"fileName": "NeonDropdownPlacementUtils.ts",
 											"line": 58,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L58"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L58"
 										}
 									],
 									"parameters": [
@@ -2911,7 +2911,7 @@
 									"fileName": "NeonDropdownPlacementUtils.ts",
 									"line": 70,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L70"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L70"
 								}
 							],
 							"signatures": [
@@ -2926,7 +2926,7 @@
 											"fileName": "NeonDropdownPlacementUtils.ts",
 											"line": 70,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L70"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L70"
 										}
 									],
 									"parameters": [
@@ -3024,7 +3024,7 @@
 							"fileName": "NeonDropdownPlacementUtils.ts",
 							"line": 10,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L10"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L10"
 						}
 					]
 				}
@@ -3042,7 +3042,7 @@
 					"fileName": "NeonDropdownPlacementUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonDropdownPlacementUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonDropdownPlacementUtils.ts#L1"
 				}
 			]
 		},
@@ -3104,7 +3104,7 @@
 									"fileName": "NeonEventBus.ts",
 									"line": 11,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L11"
 								}
 							],
 							"type": {
@@ -3133,7 +3133,7 @@
 														"fileName": "NeonEventBus.ts",
 														"line": 11,
 														"character": 49,
-														"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L11"
+														"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L11"
 													}
 												],
 												"signatures": [
@@ -3148,7 +3148,7 @@
 																"fileName": "NeonEventBus.ts",
 																"line": 11,
 																"character": 49,
-																"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L11"
+																"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L11"
 															}
 														],
 														"parameters": [
@@ -3206,7 +3206,7 @@
 									"fileName": "NeonEventBus.ts",
 									"line": 8,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L8"
 								}
 							],
 							"type": {
@@ -3229,7 +3229,7 @@
 									"fileName": "NeonEventBus.ts",
 									"line": 45,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L45"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L45"
 								}
 							],
 							"signatures": [
@@ -3252,7 +3252,7 @@
 											"fileName": "NeonEventBus.ts",
 											"line": 45,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L45"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L45"
 										}
 									],
 									"parameters": [
@@ -3321,7 +3321,7 @@
 									"fileName": "NeonEventBus.ts",
 									"line": 34,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L34"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L34"
 								}
 							],
 							"signatures": [
@@ -3344,7 +3344,7 @@
 											"fileName": "NeonEventBus.ts",
 											"line": 34,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L34"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L34"
 										}
 									],
 									"parameters": [
@@ -3394,7 +3394,7 @@
 															"fileName": "NeonEventBus.ts",
 															"line": 34,
 															"character": 45,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L34"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L34"
 														}
 													],
 													"signatures": [
@@ -3409,7 +3409,7 @@
 																	"fileName": "NeonEventBus.ts",
 																	"line": 34,
 																	"character": 45,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L34"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L34"
 																}
 															],
 															"parameters": [
@@ -3461,7 +3461,7 @@
 									"fileName": "NeonEventBus.ts",
 									"line": 20,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L20"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L20"
 								}
 							],
 							"signatures": [
@@ -3484,7 +3484,7 @@
 											"fileName": "NeonEventBus.ts",
 											"line": 20,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L20"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L20"
 										}
 									],
 									"parameters": [
@@ -3534,7 +3534,7 @@
 															"fileName": "NeonEventBus.ts",
 															"line": 20,
 															"character": 44,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L20"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L20"
 														}
 													],
 													"signatures": [
@@ -3549,7 +3549,7 @@
 																	"fileName": "NeonEventBus.ts",
 																	"line": 20,
 																	"character": 44,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L20"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L20"
 																}
 															],
 															"parameters": [
@@ -3616,7 +3616,7 @@
 							"fileName": "NeonEventBus.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L6"
 						}
 					]
 				}
@@ -3634,7 +3634,7 @@
 					"fileName": "NeonEventBus.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonEventBus.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonEventBus.ts#L1"
 				}
 			]
 		},
@@ -3656,7 +3656,7 @@
 							"fileName": "NeonFileUtils.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonFileUtils.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonFileUtils.ts#L6"
 						}
 					],
 					"signatures": [
@@ -3690,7 +3690,7 @@
 									"fileName": "NeonFileUtils.ts",
 									"line": 6,
 									"character": 29,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonFileUtils.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonFileUtils.ts#L6"
 								}
 							],
 							"parameters": [
@@ -3751,7 +3751,7 @@
 					"fileName": "NeonFileUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonFileUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonFileUtils.ts#L1"
 				}
 			]
 		},
@@ -3813,7 +3813,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 7,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L7"
 								}
 							],
 							"type": {
@@ -3851,7 +3851,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 18,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L18"
 								}
 							],
 							"signatures": [
@@ -3885,7 +3885,7 @@
 											"fileName": "NeonIconRegistry.ts",
 											"line": 18,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L18"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L18"
 										}
 									],
 									"parameters": [
@@ -3969,7 +3969,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 59,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L59"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L59"
 								}
 							],
 							"signatures": [
@@ -3992,7 +3992,7 @@
 											"fileName": "NeonIconRegistry.ts",
 											"line": 59,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L59"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L59"
 										}
 									],
 									"type": {
@@ -4016,7 +4016,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 45,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L45"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L45"
 								}
 							],
 							"signatures": [
@@ -4050,7 +4050,7 @@
 											"fileName": "NeonIconRegistry.ts",
 											"line": 45,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L45"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L45"
 										}
 									],
 									"parameters": [
@@ -4095,7 +4095,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 52,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L52"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L52"
 								}
 							],
 							"signatures": [
@@ -4118,7 +4118,7 @@
 											"fileName": "NeonIconRegistry.ts",
 											"line": 52,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L52"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L52"
 										}
 									],
 									"type": {
@@ -4145,7 +4145,7 @@
 									"fileName": "NeonIconRegistry.ts",
 									"line": 34,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L34"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L34"
 								}
 							],
 							"signatures": [
@@ -4168,7 +4168,7 @@
 											"fileName": "NeonIconRegistry.ts",
 											"line": 34,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L34"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L34"
 										}
 									],
 									"parameters": [
@@ -4229,7 +4229,7 @@
 							"fileName": "NeonIconRegistry.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L6"
 						}
 					]
 				}
@@ -4247,7 +4247,7 @@
 					"fileName": "NeonIconRegistry.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonIconRegistry.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonIconRegistry.ts#L1"
 				}
 			]
 		},
@@ -4302,7 +4302,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 4,
 									"character": 26,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L4"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L4"
 								}
 							],
 							"type": {
@@ -4326,7 +4326,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 5,
 									"character": 26,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L5"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L5"
 								}
 							],
 							"type": {
@@ -4350,7 +4350,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 6,
 									"character": 26,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L6"
 								}
 							],
 							"type": {
@@ -4373,7 +4373,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 92,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L92"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L92"
 								}
 							],
 							"signatures": [
@@ -4388,7 +4388,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 92,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L92"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L92"
 										}
 									],
 									"parameters": [
@@ -4436,7 +4436,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 81,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L81"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L81"
 								}
 							],
 							"signatures": [
@@ -4451,7 +4451,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 81,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L81"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L81"
 										}
 									],
 									"parameters": [
@@ -4488,7 +4488,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 81,
 															"character": 50,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L81"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L81"
 														}
 													],
 													"signatures": [
@@ -4503,7 +4503,7 @@
 																	"fileName": "NeonJazziconUtils.ts",
 																	"line": 81,
 																	"character": 50,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L81"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L81"
 																}
 															],
 															"type": {
@@ -4537,7 +4537,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 44,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L44"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L44"
 								}
 							],
 							"signatures": [
@@ -4552,7 +4552,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 44,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L44"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L44"
 										}
 									],
 									"parameters": [
@@ -4638,7 +4638,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 50,
 															"character": 10,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L50"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L50"
 														}
 													],
 													"signatures": [
@@ -4653,7 +4653,7 @@
 																	"fileName": "NeonJazziconUtils.ts",
 																	"line": 50,
 																	"character": 10,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L50"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L50"
 																}
 															],
 															"type": {
@@ -4687,7 +4687,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 14,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L14"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L14"
 								}
 							],
 							"signatures": [
@@ -4710,7 +4710,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 14,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L14"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L14"
 										}
 									],
 									"parameters": [
@@ -4796,7 +4796,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 18,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L18"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L18"
 								}
 							],
 							"signatures": [
@@ -4811,7 +4811,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 18,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L18"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L18"
 										}
 									],
 									"parameters": [
@@ -4859,7 +4859,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 18,
 															"character": 83,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L18"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L18"
 														}
 													],
 													"signatures": [
@@ -4874,7 +4874,7 @@
 																	"fileName": "NeonJazziconUtils.ts",
 																	"line": 18,
 																	"character": 83,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L18"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L18"
 																}
 															],
 															"type": {
@@ -4913,7 +4913,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 101,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L101"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L101"
 								}
 							],
 							"signatures": [
@@ -4928,7 +4928,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 101,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L101"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L101"
 										}
 									],
 									"parameters": [
@@ -4964,7 +4964,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 138,
 															"character": 13,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L138"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L138"
 														}
 													],
 													"type": {
@@ -4983,7 +4983,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 138,
 															"character": 19,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L138"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L138"
 														}
 													],
 													"type": {
@@ -5002,7 +5002,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 138,
 															"character": 16,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L138"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L138"
 														}
 													],
 													"type": {
@@ -5026,7 +5026,7 @@
 													"fileName": "NeonJazziconUtils.ts",
 													"line": 138,
 													"character": 11,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L138"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L138"
 												}
 											]
 										}
@@ -5048,7 +5048,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 141,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L141"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L141"
 								}
 							],
 							"signatures": [
@@ -5063,7 +5063,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 141,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L141"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L141"
 										}
 									],
 									"parameters": [
@@ -5115,7 +5115,7 @@
 									"fileName": "NeonJazziconUtils.ts",
 									"line": 86,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L86"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L86"
 								}
 							],
 							"signatures": [
@@ -5130,7 +5130,7 @@
 											"fileName": "NeonJazziconUtils.ts",
 											"line": 86,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L86"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L86"
 										}
 									],
 									"parameters": [
@@ -5167,7 +5167,7 @@
 															"fileName": "NeonJazziconUtils.ts",
 															"line": 86,
 															"character": 55,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L86"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L86"
 														}
 													],
 													"signatures": [
@@ -5182,7 +5182,7 @@
 																	"fileName": "NeonJazziconUtils.ts",
 																	"line": 86,
 																	"character": 55,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L86"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L86"
 																}
 															],
 															"type": {
@@ -5240,7 +5240,7 @@
 							"fileName": "NeonJazziconUtils.ts",
 							"line": 3,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L3"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L3"
 						}
 					]
 				}
@@ -5258,7 +5258,7 @@
 					"fileName": "NeonJazziconUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonJazziconUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonJazziconUtils.ts#L1"
 				}
 			]
 		},
@@ -5320,7 +5320,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 10,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L10"
 								}
 							],
 							"type": {
@@ -5343,7 +5343,7 @@
 													"fileName": "NeonModeUtils.ts",
 													"line": 10,
 													"character": 28,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L10"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L10"
 												}
 											],
 											"signatures": [
@@ -5358,7 +5358,7 @@
 															"fileName": "NeonModeUtils.ts",
 															"line": 10,
 															"character": 28,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L10"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L10"
 														}
 													],
 													"parameters": [
@@ -5400,7 +5400,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 8,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L8"
 								}
 							],
 							"type": {
@@ -5428,7 +5428,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 9,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L9"
 								}
 							],
 							"type": {
@@ -5456,7 +5456,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 41,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L41"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L41"
 								}
 							],
 							"signatures": [
@@ -5479,7 +5479,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 41,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L41"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L41"
 										}
 									],
 									"type": {
@@ -5503,7 +5503,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 85,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L85"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L85"
 								}
 							],
 							"signatures": [
@@ -5537,7 +5537,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 85,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L85"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L85"
 										}
 									],
 									"type": {
@@ -5566,7 +5566,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 19,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L19"
 								}
 							],
 							"signatures": [
@@ -5589,7 +5589,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 19,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L19"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L19"
 										}
 									],
 									"parameters": [
@@ -5648,7 +5648,7 @@
 															"fileName": "NeonModeUtils.ts",
 															"line": 19,
 															"character": 56,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L19"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L19"
 														}
 													],
 													"signatures": [
@@ -5663,7 +5663,7 @@
 																	"fileName": "NeonModeUtils.ts",
 																	"line": 19,
 																	"character": 56,
-																	"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L19"
+																	"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L19"
 																}
 															],
 															"parameters": [
@@ -5709,7 +5709,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 89,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L89"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L89"
 								}
 							],
 							"signatures": [
@@ -5724,7 +5724,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 89,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L89"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L89"
 										}
 									],
 									"parameters": [
@@ -5765,7 +5765,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 98,
 									"character": 9,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L98"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L98"
 								}
 							],
 							"signatures": [
@@ -5780,7 +5780,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 98,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L98"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L98"
 										}
 									],
 									"parameters": [
@@ -5822,7 +5822,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 50,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L50"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L50"
 								}
 							],
 							"signatures": [
@@ -5845,7 +5845,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 50,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L50"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L50"
 										}
 									],
 									"parameters": [
@@ -5895,7 +5895,7 @@
 									"fileName": "NeonModeUtils.ts",
 									"line": 107,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L107"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L107"
 								}
 							],
 							"signatures": [
@@ -5910,7 +5910,7 @@
 											"fileName": "NeonModeUtils.ts",
 											"line": 107,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L107"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L107"
 										}
 									],
 									"parameters": [
@@ -5967,7 +5967,7 @@
 							"fileName": "NeonModeUtils.ts",
 							"line": 7,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L7"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L7"
 						}
 					]
 				}
@@ -5985,7 +5985,7 @@
 					"fileName": "NeonModeUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonModeUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonModeUtils.ts#L1"
 				}
 			]
 		},
@@ -6047,7 +6047,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 9,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L9"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L9"
 								}
 							],
 							"type": {
@@ -6075,7 +6075,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 8,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L8"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L8"
 								}
 							],
 							"type": {
@@ -6098,7 +6098,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 7,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L7"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L7"
 								}
 							],
 							"type": {
@@ -6121,7 +6121,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 12,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L12"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L12"
 								}
 							],
 							"type": {
@@ -6144,7 +6144,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 11,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L11"
 								}
 							],
 							"type": {
@@ -6167,7 +6167,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 23,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L23"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L23"
 								}
 							],
 							"signatures": [
@@ -6201,7 +6201,7 @@
 											"fileName": "NeonNumberUtils.ts",
 											"line": 23,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L23"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L23"
 										}
 									],
 									"parameters": [
@@ -6302,7 +6302,7 @@
 									"fileName": "NeonNumberUtils.ts",
 									"line": 56,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L56"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L56"
 								}
 							],
 							"signatures": [
@@ -6336,7 +6336,7 @@
 											"fileName": "NeonNumberUtils.ts",
 											"line": 56,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L56"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L56"
 										}
 									],
 									"parameters": [
@@ -6398,7 +6398,7 @@
 							"fileName": "NeonNumberUtils.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L6"
 						}
 					]
 				}
@@ -6416,7 +6416,7 @@
 					"fileName": "NeonNumberUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonNumberUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonNumberUtils.ts#L1"
 				}
 			]
 		},
@@ -6478,7 +6478,7 @@
 									"fileName": "NeonPlacementUtils.ts",
 									"line": 19,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L19"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L19"
 								}
 							],
 							"signatures": [
@@ -6512,7 +6512,7 @@
 											"fileName": "NeonPlacementUtils.ts",
 											"line": 19,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L19"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L19"
 										}
 									],
 									"parameters": [
@@ -6631,7 +6631,7 @@
 									"fileName": "NeonPlacementUtils.ts",
 									"line": 62,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L62"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L62"
 								}
 							],
 							"signatures": [
@@ -6665,7 +6665,7 @@
 											"fileName": "NeonPlacementUtils.ts",
 											"line": 62,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L62"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L62"
 										}
 									],
 									"parameters": [
@@ -6716,7 +6716,7 @@
 															"fileName": "NeonPlacementUtils.ts",
 															"line": 71,
 															"character": 6,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L71"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L71"
 														}
 													],
 													"type": {
@@ -6736,7 +6736,7 @@
 															"fileName": "NeonPlacementUtils.ts",
 															"line": 68,
 															"character": 6,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L68"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L68"
 														}
 													],
 													"type": {
@@ -6760,7 +6760,7 @@
 													"fileName": "NeonPlacementUtils.ts",
 													"line": 67,
 													"character": 11,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L67"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L67"
 												}
 											]
 										}
@@ -6789,7 +6789,7 @@
 							"fileName": "NeonPlacementUtils.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L6"
 						}
 					]
 				}
@@ -6807,7 +6807,7 @@
 					"fileName": "NeonPlacementUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonPlacementUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonPlacementUtils.ts#L1"
 				}
 			]
 		},
@@ -6861,7 +6861,7 @@
 									"fileName": "NeonRandomUtils.ts",
 									"line": 6,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L6"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L6"
 								}
 							],
 							"signatures": [
@@ -6876,7 +6876,7 @@
 											"fileName": "NeonRandomUtils.ts",
 											"line": 6,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L6"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L6"
 										}
 									],
 									"parameters": [
@@ -6916,7 +6916,7 @@
 									"fileName": "NeonRandomUtils.ts",
 									"line": 26,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L26"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L26"
 								}
 							],
 							"signatures": [
@@ -6931,7 +6931,7 @@
 											"fileName": "NeonRandomUtils.ts",
 											"line": 26,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L26"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L26"
 										}
 									],
 									"parameters": [
@@ -6960,7 +6960,7 @@
 													"fileName": "NeonRandomUtils.ts",
 													"line": 27,
 													"character": 11,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L27"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L27"
 												}
 											],
 											"signatures": [
@@ -6975,7 +6975,7 @@
 															"fileName": "NeonRandomUtils.ts",
 															"line": 27,
 															"character": 11,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L27"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L27"
 														}
 													],
 													"type": {
@@ -7003,7 +7003,7 @@
 									"fileName": "NeonRandomUtils.ts",
 									"line": 2,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L2"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L2"
 								}
 							],
 							"signatures": [
@@ -7018,7 +7018,7 @@
 											"fileName": "NeonRandomUtils.ts",
 											"line": 2,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L2"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L2"
 										}
 									],
 									"parameters": [
@@ -7047,7 +7047,7 @@
 													"fileName": "NeonRandomUtils.ts",
 													"line": 2,
 													"character": 36,
-													"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L2"
+													"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L2"
 												}
 											],
 											"signatures": [
@@ -7062,7 +7062,7 @@
 															"fileName": "NeonRandomUtils.ts",
 															"line": 2,
 															"character": 36,
-															"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L2"
+															"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L2"
 														}
 													],
 													"type": {
@@ -7098,7 +7098,7 @@
 							"fileName": "NeonRandomUtils.ts",
 							"line": 1,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L1"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L1"
 						}
 					]
 				}
@@ -7116,7 +7116,7 @@
 					"fileName": "NeonRandomUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonRandomUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonRandomUtils.ts#L1"
 				}
 			]
 		},
@@ -7187,7 +7187,7 @@
 									"fileName": "NeonResponsiveUtils.ts",
 									"line": 11,
 									"character": 25,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonResponsiveUtils.ts#L11"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonResponsiveUtils.ts#L11"
 								}
 							],
 							"type": {
@@ -7236,7 +7236,7 @@
 							"fileName": "NeonResponsiveUtils.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonResponsiveUtils.ts#L6"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonResponsiveUtils.ts#L6"
 						}
 					]
 				}
@@ -7254,7 +7254,7 @@
 					"fileName": "NeonResponsiveUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonResponsiveUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonResponsiveUtils.ts#L1"
 				}
 			]
 		},
@@ -7316,7 +7316,7 @@
 									"fileName": "NeonScrollUtils.ts",
 									"line": 10,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonScrollUtils.ts#L10"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonScrollUtils.ts#L10"
 								}
 							],
 							"signatures": [
@@ -7339,7 +7339,7 @@
 											"fileName": "NeonScrollUtils.ts",
 											"line": 10,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonScrollUtils.ts#L10"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonScrollUtils.ts#L10"
 										}
 									],
 									"parameters": [
@@ -7395,7 +7395,7 @@
 							"fileName": "NeonScrollUtils.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonScrollUtils.ts#L4"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonScrollUtils.ts#L4"
 						}
 					]
 				}
@@ -7413,7 +7413,7 @@
 					"fileName": "NeonScrollUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonScrollUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonScrollUtils.ts#L1"
 				}
 			]
 		},
@@ -7475,7 +7475,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 57,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L57"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L57"
 								}
 							],
 							"signatures": [
@@ -7490,7 +7490,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 57,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L57"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L57"
 										}
 									],
 									"parameters": [
@@ -7548,7 +7548,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 42,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L42"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L42"
 								}
 							],
 							"signatures": [
@@ -7571,7 +7571,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 42,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L42"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L42"
 										}
 									],
 									"parameters": [
@@ -7621,7 +7621,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 53,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L53"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L53"
 								}
 							],
 							"signatures": [
@@ -7655,7 +7655,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 53,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L53"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L53"
 										}
 									],
 									"parameters": [
@@ -7705,7 +7705,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 15,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L15"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L15"
 								}
 							],
 							"signatures": [
@@ -7728,7 +7728,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 15,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L15"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L15"
 										}
 									],
 									"parameters": [
@@ -7778,7 +7778,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 24,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L24"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L24"
 								}
 							],
 							"signatures": [
@@ -7801,7 +7801,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 24,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L24"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L24"
 										}
 									],
 									"parameters": [
@@ -7851,7 +7851,7 @@
 									"fileName": "NeonToastService.ts",
 									"line": 33,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L33"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L33"
 								}
 							],
 							"signatures": [
@@ -7874,7 +7874,7 @@
 											"fileName": "NeonToastService.ts",
 											"line": 33,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L33"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L33"
 										}
 									],
 									"parameters": [
@@ -7935,7 +7935,7 @@
 							"fileName": "NeonToastService.ts",
 							"line": 9,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L9"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L9"
 						}
 					]
 				}
@@ -7953,7 +7953,7 @@
 					"fileName": "NeonToastService.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonToastService.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonToastService.ts#L1"
 				}
 			]
 		},
@@ -8015,7 +8015,7 @@
 									"fileName": "NeonTooltipPlacementUtils.ts",
 									"line": 22,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L22"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L22"
 								}
 							],
 							"signatures": [
@@ -8049,7 +8049,7 @@
 											"fileName": "NeonTooltipPlacementUtils.ts",
 											"line": 22,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L22"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L22"
 										}
 									],
 									"parameters": [
@@ -8178,7 +8178,7 @@
 									"fileName": "NeonTooltipPlacementUtils.ts",
 									"line": 41,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L41"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L41"
 								}
 							],
 							"signatures": [
@@ -8193,7 +8193,7 @@
 											"fileName": "NeonTooltipPlacementUtils.ts",
 											"line": 41,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L41"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L41"
 										}
 									],
 									"parameters": [
@@ -8243,7 +8243,7 @@
 									"fileName": "NeonTooltipPlacementUtils.ts",
 									"line": 54,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L54"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L54"
 								}
 							],
 							"signatures": [
@@ -8258,7 +8258,7 @@
 											"fileName": "NeonTooltipPlacementUtils.ts",
 											"line": 54,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L54"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L54"
 										}
 									],
 									"parameters": [
@@ -8340,7 +8340,7 @@
 									"fileName": "NeonTooltipPlacementUtils.ts",
 									"line": 65,
 									"character": 17,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L65"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L65"
 								}
 							],
 							"signatures": [
@@ -8355,7 +8355,7 @@
 											"fileName": "NeonTooltipPlacementUtils.ts",
 											"line": 65,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L65"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L65"
 										}
 									],
 									"parameters": [
@@ -8438,7 +8438,7 @@
 							"fileName": "NeonTooltipPlacementUtils.ts",
 							"line": 8,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L8"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L8"
 						}
 					]
 				}
@@ -8456,7 +8456,7 @@
 					"fileName": "NeonTooltipPlacementUtils.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/NeonTooltipPlacementUtils.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/NeonTooltipPlacementUtils.ts#L1"
 				}
 			]
 		},
@@ -8518,7 +8518,7 @@
 									"fileName": "RegisterIcons.ts",
 									"line": 61,
 									"character": 16,
-									"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/RegisterIcons.ts#L61"
+									"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/RegisterIcons.ts#L61"
 								}
 							],
 							"signatures": [
@@ -8541,7 +8541,7 @@
 											"fileName": "RegisterIcons.ts",
 											"line": 61,
 											"character": 2,
-											"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/RegisterIcons.ts#L61"
+											"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/RegisterIcons.ts#L61"
 										}
 									],
 									"type": {
@@ -8571,7 +8571,7 @@
 							"fileName": "RegisterIcons.ts",
 							"line": 56,
 							"character": 13,
-							"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/RegisterIcons.ts#L56"
+							"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/RegisterIcons.ts#L56"
 						}
 					]
 				}
@@ -8589,7 +8589,7 @@
 					"fileName": "RegisterIcons.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/aotearoan/neon/blob/fa3b6fb/src/common/utils/RegisterIcons.ts#L1"
+					"url": "https://github.com/aotearoan/neon/blob/39feebc/src/common/utils/RegisterIcons.ts#L1"
 				}
 			]
 		}

--- a/src/app/views/design/kitchen-sink/KitchenSink.vue
+++ b/src/app/views/design/kitchen-sink/KitchenSink.vue
@@ -70,7 +70,7 @@
               placeholder="Placeholder..."
             />
           </neon-field>
-          <neon-field-group>
+          <neon-field-group indicator-style="external">
             <neon-input-indicator :disabled="disabled" aria-label="Username" for="userField" icon="user" />
             <neon-input
               id="userField"

--- a/src/app/views/user-input/field-group/FieldGroup.ts
+++ b/src/app/views/user-input/field-group/FieldGroup.ts
@@ -4,6 +4,7 @@ import {
   NeonCard,
   NeonCardBody,
   NeonCardHeader,
+  NeonField,
   NeonFieldGroup,
   NeonInput,
   NeonInputIndicator,
@@ -26,6 +27,7 @@ export default defineComponent({
     NeonCardHeader,
     NeonInput,
     NeonInputIndicator,
+    NeonField,
     NeonFieldGroup,
     NeonSelect,
     NeonStack,
@@ -64,19 +66,48 @@ export default defineComponent({
       },
     ]);
 
-    const inputIndicatorExamples = `<neon-field-group>
-  <neon-input-indicator size="s" label="Salary" />
-  <neon-input size="s" type="text" color="primary" v-model="indexFilter" placeholder="Enter amount" />
-  <neon-select size="s" color="primary" v-model="currency" :options="currencies" placeholder="Currency" />
+    const inputIndicatorInternalExamples = `<neon-field-group>
+  <neon-input-indicator label="Salary" size="s"/>
+  <neon-input v-model="indexFilter" color="primary" placeholder="Enter amount" size="s" type="text"/>
+  <neon-input-indicator label="USD" size="s"/>
 </neon-field-group>
 <neon-field-group>
-  <neon-input type="text" color="primary" v-model="indexFilter" placeholder="Enter rate" />
-  <neon-input-indicator label="%" />
+  <neon-input v-model="indexFilter" color="primary" placeholder="Enter rate" type="text"/>
+  <neon-input-indicator label="%"/>
 </neon-field-group>
-<neon-field-group>
-  <neon-input-indicator size="l" label="$" />
-  <neon-input size="l" type="text" v-model="indexFilter" placeholder="Enter amount" />
-  <neon-button size="l" label="Submit" />
+<neon-field for="largeField" label="Large field">
+  <neon-field-group>
+    <neon-input-indicator for="largeField" label="USD" size="l"/>
+    <neon-input id="largeField" v-model="indexFilter" placeholder="Enter amount" size="l" type="text"/>
+  </neon-field-group>
+</neon-field>
+<neon-field for="largeDisabledField" label="Disabled field">
+  <neon-field-group :disabled="true">
+    <neon-input-indicator for="largeDisabledField" label="USD" size="l" :disabled="true"/>
+    <neon-input
+      id="largeDisabledField"
+      v-model="indexFilter"
+      placeholder="Enter amount"
+      size="l"
+      type="text"
+      :disabled="true"
+    />
+  </neon-field-group>
+</neon-field>`;
+
+    const inputIndicatorExternalExamples = `<neon-field-group indicator-style="external">
+  <neon-input-indicator label="Salary" size="s"/>
+  <neon-input v-model="indexFilter" color="primary" placeholder="Enter amount" size="s" type="text"/>
+  <neon-select v-model="currency" :options="currencies" color="primary" placeholder="Currency" size="s"/>
+</neon-field-group>
+<neon-field-group indicator-style="external">
+  <neon-input v-model="indexFilter" color="primary" placeholder="Enter rate" type="text"/>
+  <neon-input-indicator label="%"/>
+</neon-field-group>
+<neon-field-group indicator-style="external">
+  <neon-input-indicator label="$" size="l"/>
+  <neon-input v-model="indexFilter" placeholder="Enter amount" size="l" type="text"/>
+  <neon-button color="low-contrast" label="Submit" size="l"/>
 </neon-field-group>`;
 
     onMounted(() => (menuModel.value = Menu.getComponentConfig('NeonFieldGroup')));
@@ -84,7 +115,8 @@ export default defineComponent({
     return {
       menuModel,
       headline,
-      inputIndicatorExamples,
+      inputIndicatorInternalExamples,
+      inputIndicatorExternalExamples,
       indexFilter,
       currency,
       currencies,

--- a/src/app/views/user-input/field-group/FieldGroup.vue
+++ b/src/app/views/user-input/field-group/FieldGroup.vue
@@ -14,25 +14,61 @@
         </neon-stack>
       </neon-card-body>
       <neon-card-body>
-        <h2 class="neon-h3">Field Group Examples</h2>
+        <h2 class="neon-h3">Field Group internal style examples</h2>
         <neon-stack>
-          <neon-stack>
+          <neon-stack gap="m">
             <neon-field-group>
               <neon-input-indicator label="Salary" size="s" />
               <neon-input v-model="indexFilter" color="primary" placeholder="Enter amount" size="s" type="text" />
-              <neon-select v-model="currency" :options="currencies" color="primary" placeholder="Currency" size="s" />
+              <neon-input-indicator label="USD" size="s" />
             </neon-field-group>
             <neon-field-group>
               <neon-input v-model="indexFilter" color="primary" placeholder="Enter rate" type="text" />
               <neon-input-indicator label="%" />
             </neon-field-group>
-            <neon-field-group>
+            <neon-field for="largeField" label="Large field">
+              <neon-field-group>
+                <neon-input-indicator for="largeField" label="USD" size="l" />
+                <neon-input id="largeField" v-model="indexFilter" placeholder="Enter amount" size="l" type="text" />
+              </neon-field-group>
+            </neon-field>
+            <neon-field for="largeDisabledField" label="Disabled field">
+              <neon-field-group :disabled="true">
+                <neon-input-indicator :disabled="true" for="largeDisabledField" label="USD" size="l" />
+                <neon-input
+                  id="largeDisabledField"
+                  v-model="indexFilter"
+                  :disabled="true"
+                  placeholder="Enter amount"
+                  size="l"
+                  type="text"
+                />
+              </neon-field-group>
+            </neon-field>
+          </neon-stack>
+          <editor v-model="inputIndicatorInternalExamples" />
+        </neon-stack>
+      </neon-card-body>
+      <neon-card-body>
+        <h2 class="neon-h3">Field Group external style examples</h2>
+        <neon-stack>
+          <neon-stack gap="m">
+            <neon-field-group indicator-style="external">
+              <neon-input-indicator label="Salary" size="s" />
+              <neon-input v-model="indexFilter" color="primary" placeholder="Enter amount" size="s" type="text" />
+              <neon-select v-model="currency" :options="currencies" color="primary" placeholder="Currency" size="s" />
+            </neon-field-group>
+            <neon-field-group indicator-style="external">
+              <neon-input v-model="indexFilter" color="primary" placeholder="Enter rate" type="text" />
+              <neon-input-indicator label="%" />
+            </neon-field-group>
+            <neon-field-group indicator-style="external">
               <neon-input-indicator label="$" size="l" />
               <neon-input v-model="indexFilter" placeholder="Enter amount" size="l" type="text" />
               <neon-button color="low-contrast" label="Submit" size="l" />
             </neon-field-group>
           </neon-stack>
-          <editor v-model="inputIndicatorExamples" />
+          <editor v-model="inputIndicatorExternalExamples" />
         </neon-stack>
       </neon-card-body>
     </neon-card>

--- a/src/app/views/user-input/input-indicator/InputIndicator.ts
+++ b/src/app/views/user-input/input-indicator/InputIndicator.ts
@@ -34,18 +34,32 @@ export default defineComponent({
     const field2 = ref('');
     const field3 = ref('');
 
-    const inputIndicatorExamples = `<neon-field-group>
+    const internalInputIndicatorExamples = `<neon-field-group>
   <neon-input v-model="field1" placeholder="Rate" size="s" type="text" />
   <neon-input-indicator label="%" size="s" />
 </neon-field-group>
 <neon-field-group>
-  <neon-input-indicator aria-label="Username" for="userField" icon="user" />
+  <neon-input-indicator aria-label="Username" for="userField" icon="single-neutral" />
   <neon-input id="userField" v-model="field2" placeholder="Username" type="text" />
 </neon-field-group>
 <neon-field-group>
-  <neon-input-indicator icon="mail" size="l" />
+  <neon-input-indicator icon="envelope" size="l" />
   <neon-input v-model="field3" placeholder="Username" size="l" type="text" />
   <neon-input-indicator label="@aol.com" size="l" />
+</neon-field-group>`;
+
+    const externalInputIndicatorExamples = `<neon-field-group indicator-style="external">
+  <neon-input v-model="field1" placeholder="Rate" size="s" type="text"/>
+  <neon-input-indicator label="%" size="s"/>
+</neon-field-group>
+<neon-field-group indicator-style="external">
+  <neon-input-indicator aria-label="Username" for="userField" icon="single-neutral"/>
+  <neon-input id="userField" v-model="field2" placeholder="Username" type="text"/>
+</neon-field-group>
+<neon-field-group indicator-style="external">
+  <neon-input-indicator icon="envelope" size="l"/>
+  <neon-input v-model="field3" placeholder="Username" size="l" type="text"/>
+  <neon-input-indicator label="@aol.com" size="l"/>
 </neon-field-group>`;
 
     onMounted(() => (menuModel.value = Menu.getComponentConfig('NeonInputIndicator')));
@@ -53,7 +67,8 @@ export default defineComponent({
     return {
       menuModel,
       headline,
-      inputIndicatorExamples,
+      internalInputIndicatorExamples,
+      externalInputIndicatorExamples,
       field1,
       field2,
       field3,

--- a/src/app/views/user-input/input-indicator/InputIndicator.vue
+++ b/src/app/views/user-input/input-indicator/InputIndicator.vue
@@ -16,24 +16,45 @@
         </neon-stack>
       </neon-card-body>
       <neon-card-body>
-        <h2 class="neon-h3">Input Indicator Examples</h2>
+        <h2 class="neon-h3">Internal input indicator examples</h2>
         <neon-stack>
-          <neon-stack>
+          <neon-stack gap="m">
             <neon-field-group>
               <neon-input v-model="field1" placeholder="Rate" size="s" type="text" />
               <neon-input-indicator label="%" size="s" />
             </neon-field-group>
             <neon-field-group>
-              <neon-input-indicator aria-label="Username" for="userField" icon="user" />
+              <neon-input-indicator aria-label="Username" for="userField" icon="single-neutral" />
               <neon-input id="userField" v-model="field2" placeholder="Username" type="text" />
             </neon-field-group>
             <neon-field-group>
-              <neon-input-indicator icon="mail" size="l" />
+              <neon-input-indicator icon="envelope" size="l" />
               <neon-input v-model="field3" placeholder="Username" size="l" type="text" />
               <neon-input-indicator label="@aol.com" size="l" />
             </neon-field-group>
           </neon-stack>
-          <editor v-model="inputIndicatorExamples" />
+          <editor v-model="internalInputIndicatorExamples" />
+        </neon-stack>
+      </neon-card-body>
+      <neon-card-body>
+        <h2 class="neon-h3">External input indicator examples</h2>
+        <neon-stack>
+          <neon-stack gap="m">
+            <neon-field-group indicator-style="external">
+              <neon-input v-model="field1" placeholder="Rate" size="s" type="text" />
+              <neon-input-indicator label="%" size="s" />
+            </neon-field-group>
+            <neon-field-group indicator-style="external">
+              <neon-input-indicator aria-label="Username" for="userField" icon="single-neutral" />
+              <neon-input id="userField" v-model="field2" placeholder="Username" type="text" />
+            </neon-field-group>
+            <neon-field-group indicator-style="external">
+              <neon-input-indicator icon="envelope" size="l" />
+              <neon-input v-model="field3" placeholder="Username" size="l" type="text" />
+              <neon-input-indicator label="@aol.com" size="l" />
+            </neon-field-group>
+          </neon-stack>
+          <editor v-model="externalInputIndicatorExamples" />
         </neon-stack>
       </neon-card-body>
     </neon-card>

--- a/src/common/enums/NeonInputIndicatorStyle.ts
+++ b/src/common/enums/NeonInputIndicatorStyle.ts
@@ -1,0 +1,10 @@
+export enum NeonInputIndicatorStyle {
+  /**
+   * Display input indicator INSIDE the adjacent input.
+   */
+  Internal = 'internal',
+  /**
+   * Display input indicator OUTSIDE the adjacent input.
+   */
+  External = 'external',
+}

--- a/src/components/user-input/field-group/NeonFieldGroup.spec.ts
+++ b/src/components/user-input/field-group/NeonFieldGroup.spec.ts
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/vue';
 import NeonFieldGroup from './NeonFieldGroup.vue';
+import { NeonInputIndicatorStyle } from '@/common/enums/NeonInputIndicatorStyle';
+import { NeonFunctionalColor } from '@/common/enums/NeonFunctionalColor';
 
 describe('NeonFieldGroup', () => {
   it('renders default slot', () => {
@@ -11,5 +13,50 @@ describe('NeonFieldGroup', () => {
     });
     // when / then
     expect(container.querySelector('.neon-field-group p')?.textContent).toEqual(content);
+  });
+
+  it('renders internal indicator style by default', () => {
+    // given
+    const { container } = render(NeonFieldGroup);
+    // when / then
+    expect(container.querySelector('.neon-field-group--internal')).toBeDefined();
+  });
+
+  it('renders external indicator style', async () => {
+    // given
+    const { container, rerender } = render(NeonFieldGroup);
+    await rerender({ indicatorStyle: NeonInputIndicatorStyle.External });
+    // when / then
+    expect(container.querySelector('.neon-field-group--external')).toBeDefined();
+  });
+
+  it('renders default color', () => {
+    // given
+    const { container } = render(NeonFieldGroup);
+    // when / then
+    expect(container.querySelector('.neon-field-group--primary')).toBeDefined();
+  });
+
+  it('renders color', async () => {
+    // given
+    const { container, rerender } = render(NeonFieldGroup);
+    await rerender({ color: NeonFunctionalColor.Brand });
+    // when / then
+    expect(container.querySelector('.neon-field-group--brand')).toBeDefined();
+  });
+
+  it('renders enabled', () => {
+    // given
+    const { container } = render(NeonFieldGroup);
+    // when / then
+    expect(container.querySelector('.neon-field-group--disabled')).toBeNull();
+  });
+
+  it('renders disabled', async () => {
+    // given
+    const { container, rerender } = render(NeonFieldGroup);
+    await rerender({ disabled: true });
+    // when / then
+    expect(container.querySelector('.neon-field-group--disabled')).toBeDefined();
   });
 });

--- a/src/components/user-input/field-group/NeonFieldGroup.ts
+++ b/src/components/user-input/field-group/NeonFieldGroup.ts
@@ -1,8 +1,26 @@
 import { defineComponent } from 'vue';
+import { NeonFunctionalColor } from '@/common/enums/NeonFunctionalColor';
+import { NeonInputIndicatorStyle } from '@/common/enums/NeonInputIndicatorStyle';
 
 /**
  * Used to compose a group of inputs, buttons and input indicators into a single component.
  */
 export default defineComponent({
   name: 'NeonFieldGroup',
+  props: {
+    /**
+     * The style of input indicators to use, either <em>internal</em> where the indicator is inside the adjoined input
+     * field or <em>external</em> where the indicator is external to the adjoining field separated by a border & not
+     * highlighted as part of the field.
+     */
+    indicatorStyle: { type: String as () => NeonInputIndicatorStyle, default: NeonInputIndicatorStyle.Internal },
+    /**
+     * The border highlight color when the indicator style is <em>internal</em>.
+     */
+    color: { type: String as () => NeonFunctionalColor, default: NeonFunctionalColor.Primary },
+    /**
+     * Use the disabled color styles when the indicator style is <em>internal</em>.
+     */
+    disabled: { type: Boolean, default: false },
+  },
 });

--- a/src/components/user-input/field-group/NeonFieldGroup.vue
+++ b/src/components/user-input/field-group/NeonFieldGroup.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="neon-field-group">
+  <div
+    :class="[
+      `neon-field-group--${indicatorStyle}`,
+      `neon-field-group--${color}`,
+      { 'neon-field-group--disabled': disabled },
+    ]"
+    class="neon-field-group"
+  >
     <!-- @slot The slot for the inputs, buttons and input indicators to compose into a single component -->
     <slot></slot>
   </div>

--- a/src/components/user-input/number/NeonNumber.vue
+++ b/src/components/user-input/number/NeonNumber.vue
@@ -10,6 +10,7 @@
       },
     ]"
     class="neon-number"
+    indicator-style="external"
   >
     <neon-button
       v-if="spinButtons"

--- a/src/neon.ts
+++ b/src/neon.ts
@@ -77,6 +77,7 @@ export { NeonDropdownPlacement } from './common/enums/NeonDropdownPlacement';
 export { NeonDropdownStyle } from './common/enums/NeonDropdownStyle';
 export { NeonFunctionalColor } from './common/enums/NeonFunctionalColor';
 export { NeonHorizontalPosition } from './common/enums/NeonHorizontalPosition';
+export { NeonInputIndicatorStyle } from './common/enums/NeonInputIndicatorStyle';
 export { NeonInputMode } from './common/enums/NeonInputMode';
 export { NeonInputType } from './common/enums/NeonInputType';
 export { NeonLabelSize } from './common/enums/NeonLabelSize';

--- a/src/sass/components/_field-group.scss
+++ b/src/sass/components/_field-group.scss
@@ -1,60 +1,147 @@
+@use '../includes/palettes';
+
 @mixin field-group {
   .neon-field-group {
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
 
-    & > *,
-    & > .neon-input,
-    & > .neon-select {
-      &,
-      & > input,
-      & .neon-button {
-        border-radius: 0;
-        min-height: 100%;
-      }
-
-      &:first-child {
+    &.neon-field-group--external {
+      & > *,
+      & > .neon-input,
+      & > .neon-select {
         &,
         & > input,
         & .neon-button {
-          border-top-left-radius: var(--neon-border-radius);
-          border-bottom-left-radius: var(--neon-border-radius);
+          border-radius: 0;
+          min-height: 100%;
         }
-      }
 
-      &:not(:first-child) {
-        &,
-        & > input,
-        & .neon-button {
-          &:not(:focus) {
-            border-left: none;
+        &:first-child {
+          &,
+          & > input,
+          & .neon-button {
+            border-top-left-radius: var(--neon-border-radius-input);
+            border-bottom-left-radius: var(--neon-border-radius-input);
           }
         }
 
-        & > input,
-        & .neon-button {
-          &:focus {
-            margin-left: calc(-1 * var(--neon-border-width));
-            margin-right: calc(-1 * var(--neon-border-width));
-            width: calc(100% + 2 * var(--neon-border-width));
+        &:not(:first-child) {
+          &,
+          & > input,
+          & .neon-button {
+            &:not(:focus) {
+              border-left: none;
+            }
+          }
+
+          & > input,
+          & .neon-button {
+            &:focus {
+              margin-left: calc(-1 * var(--neon-border-width));
+              margin-right: calc(-1 * var(--neon-border-width));
+              width: calc(100% + 2 * var(--neon-border-width));
+            }
+          }
+        }
+
+        &:last-child {
+          &,
+          & > input,
+          & .neon-button {
+            border-top-right-radius: var(--neon-border-radius-input);
+            border-bottom-right-radius: var(--neon-border-radius-input);
           }
         }
       }
 
-      &:last-child {
-        &,
-        & > input,
-        & .neon-button {
-          border-top-right-radius: var(--neon-border-radius);
-          border-bottom-right-radius: var(--neon-border-radius);
+      & > .neon-input {
+        & > input:focus {
+          max-width: 100%;
         }
       }
     }
 
-    & > .neon-input {
-      & > input:focus {
-        max-width: 100%;
+    &.neon-field-group--internal {
+      border: var(--neon-border-width-input) var(--neon-border-style) var(--neon-border-color-input);
+      border-radius: var(--neon-border-radius-input);
+
+      .neon-input-indicator {
+        background-color: var(--neon-background-color-input);
+
+        &:not(:last-child) {
+          .neon-input-indicator__label {
+            padding-right: 0;
+          }
+
+          .neon-input-indicator__icon {
+            min-width: 16rem;
+            margin-left: var(--neon-space-12);
+            width: 16rem;
+
+            svg {
+              width: 16rem;
+              min-width: 16rem;
+            }
+          }
+        }
+      }
+
+      @each $color in palettes.$neon-functional-colors {
+        &.neon-field-group--#{$color} {
+          &:focus-within {
+            border-color: var(--neon-color-#{$color});
+
+            .neon-input-indicator {
+              background-color: rgba(var(--neon-rgb-#{$color}), var(--neon-opacity-input-background-active));
+            }
+          }
+        }
+      }
+
+      &.neon-field-group--disabled {
+        border-color: var(--neon-color-disabled-border);
+
+        .neon-input-indicator {
+          background-color: var(--neon-color-disabled-background);
+
+        }
+      }
+
+      & > *,
+      & > .neon-input-indicator,
+      & > .neon-input {
+        &,
+        & > input {
+          border-radius: 0;
+          border: none;
+          min-height: 100%;
+        }
+      }
+
+      & > .neon-input {
+        & > input:focus {
+          max-width: 100%;
+        }
+      }
+
+      & > *,
+      & > .neon-input {
+        &:first-child {
+          &,
+          & > input {
+            border-top-left-radius: var(--neon-border-radius-input);
+            border-bottom-left-radius: var(--neon-border-radius-input);
+          }
+        }
+
+        &:last-child {
+          &,
+          & > input {
+            border-top-right-radius: var(--neon-border-radius-input);
+            border-bottom-right-radius: var(--neon-border-radius-input);
+          }
+        }
       }
     }
   }

--- a/src/sass/components/_input-indicator.scss
+++ b/src/sass/components/_input-indicator.scss
@@ -20,13 +20,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      font-weight: var(--neon-font-weight-input-indicator);
+      padding-left: var(--neon-space-12);
+      padding-right: var(--neon-space-12);
     }
 
     &--s {
       height: var(--neon-size-s);
 
       .neon-input-indicator__label {
-        @include layout.padding-horizontal(0.33, 0.33);
+        font-size: var(--neon-font-size-input-indicator-s);
       }
 
       .neon-input-indicator__label,
@@ -35,8 +38,8 @@
       }
 
       .neon-icon {
-        width: var(--neon-font-size-m);
-        height: var(--neon-font-size-m);
+        width: var(--neon-font-size-input-indicator-s);
+        height: var(--neon-font-size-input-indicator-s);
       }
     }
 
@@ -44,7 +47,7 @@
       height: var(--neon-size-m);
 
       .neon-input-indicator__label {
-        @include layout.padding-horizontal(0.5, 0.5);
+        font-size: var(--neon-font-size-input-indicator-m);
       }
 
       .neon-input-indicator__label,
@@ -53,8 +56,8 @@
       }
 
       .neon-icon {
-        width: var(--neon-font-size-l);
-        height: var(--neon-font-size-l);
+        width: var(--neon-font-size-input-indicator-m);
+        height: var(--neon-font-size-input-indicator-m);
       }
     }
 
@@ -62,7 +65,7 @@
       height: var(--neon-size-l);
 
       .neon-input-indicator__label {
-        @include layout.padding-horizontal(0.5, 0.5);
+        font-size: var(--neon-font-size-input-indicator-l);
       }
 
       .neon-input-indicator__label,
@@ -71,8 +74,8 @@
       }
 
       .neon-icon {
-        width: var(--neon-font-size-l);
-        height: var(--neon-font-size-l);
+        width: var(--neon-font-size-input-indicator-l);
+        height: var(--neon-font-size-input-indicator-l);
       }
     }
 
@@ -80,6 +83,7 @@
       border: var(--neon-border-width) var(--neon-border-style) var(--neon-color-disabled-border);
       background-color: var(--neon-color-disabled-background);
       color: var(--neon-color-disabled-text);
+      cursor: not-allowed;
     }
   }
 }

--- a/src/sass/components/_input.scss
+++ b/src/sass/components/_input.scss
@@ -1,9 +1,9 @@
 @use '../includes/palettes';
 
-@mixin input-size($size, $font-size) {
+@mixin input-size($size) {
   .neon-input__text,
   .neon-input__textarea {
-    font-size: var(--neon-font-size-#{$font-size});
+    font-size: var(--neon-font-size-input-#{$size});
   }
 
   .neon-input__text {
@@ -19,31 +19,32 @@
       position: absolute;
 
       @if ($size == 's') {
-        width: calc(var(--neon-size-#{$size}) - var(--neon-space-10));
-        height: calc(var(--neon-size-#{$size}) - var(--neon-space-10));
-        top: calc(1.25 * var(--neon-space-4));
-        right: calc(1.25 * var(--neon-space-4));
+        width: calc(var(--neon-size-#{$size}) - 2.5 * var(--neon-base-space));
+        height: calc(var(--neon-size-#{$size}) - 2.5 * var(--neon-base-space));
+        top: calc(1.25 * var(--neon-base-space));
+        right: calc(1.25 * var(--neon-base-space));
 
-        padding: var(--neon-space-2);
+        padding: calc(0.5 * var(--neon-base-space));
         &.neon-icon--name-close {
-          padding: var(--neon-space-4);
+          padding: var(--neon-base-space);
         }
       } @else {
-        width: calc(var(--neon-size-#{$size}) - var(--neon-space-12));
-        height: calc(var(--neon-size-#{$size}) - var(--neon-space-12));
-        top: var(--neon-space-6);
-        right: var(--neon-space-6);
+        width: calc(var(--neon-size-#{$size}) - 3 * var(--neon-base-space));
+        height: calc(var(--neon-size-#{$size}) - 3 * var(--neon-base-space));
+        top: calc(1.5 * var(--neon-base-space));
+        right: calc(1.5 * var(--neon-base-space));
 
-        padding: var(--neon-space-4);
+        padding: calc(1 * var(--neon-base-space));
 
         &.neon-icon--name-close {
           @if ($size == 'l') {
-            padding: calc(2.25 * var(--neon-space-4));
+            padding: calc(2.25 * var(--neon-base-space));
           } @else {
-            padding: calc(1.5 * var(--neon-space-4));
+            padding: calc(1.5 * var(--neon-base-space));
           }
         }
       }
+
       cursor: default;
       border-radius: 50%;
 
@@ -63,10 +64,14 @@
 @mixin input {
   .neon-input {
     width: 100%;
-    position: relative;
+
+    &,
+    &__textarea,
+    &__textarea-wrapper {
+      position: relative;
+    }
 
     @each $color in palettes.$neon-functional-colors {
-      $input-rgb: var(--neon-rgb-#{$color});
       &.neon-input--#{$color} {
         &.neon-input--focused {
           .neon-input__text,
@@ -109,23 +114,23 @@
     }
 
     &--s {
-      @include input-size('s', 's');
+      @include input-size('s');
     }
 
     &--m {
-      @include input-size('m', 'm');
+      @include input-size('m');
     }
 
     &--l {
-      @include input-size('l', 'm');
+      @include input-size('l');
     }
 
     &__text,
     &__textarea {
       border-radius: var(--neon-border-radius-input);
       border: var(--neon-border-width-input) var(--neon-border-style);
-      padding: var(--neon-space-4) var(--neon-space-10);
-      line-height: var(--neon-line-height-one);
+      padding: var(--neon-base-space) calc(2 * var(--neon-base-space));
+      line-height: var(--neon-line-height-input);
       outline: none;
       font-family: var(--neon-font-family-body);
       width: 100%;
@@ -133,21 +138,24 @@
       color: var(--neon-color-input);
       background-color: var(--neon-background-color-input);
       box-shadow: var(--neon-inset-shadow);
+      font-weight: var(--neon-font-weight-input);
 
       &::placeholder {
         font-family: var(--neon-font-family-body);
-        letter-spacing: var(--neon-letter-spacing-s);
+        font-size: var(--neon-font-size-placeholder);
+        font-style: var(--neon-font-style-placeholder);
+        font-weight: var(--neon-font-weight-placeholder);
         color: var(--neon-color-placeholder);
       }
 
       &-counter {
-        position: absolute;
-        bottom: var(--neon-space-8);
-        right: var(--neon-space-8);
+        align-self: flex-end;
         user-select: none;
-        font-size: var(--neon-font-size-s);
+        font-size: var(--neon-font-size-xs);
+        font-weight: var(--neon-font-weight-normal);
         letter-spacing: var(--neon-letter-spacing-s);
-        color: var(--neon-color-placeholder);
+        color: var(--neon-color-text-tertiary);
+        margin-bottom: var(--neon-space-4);
       }
     }
 

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -319,7 +319,22 @@
   /* input */
   --neon-border-radius-input: var(--neon-border-radius);
   --neon-border-width-input: var(--neon-border-width);
+  --neon-font-size-placeholder: var(--neon-font-size-s);
+  --neon-font-style-placeholder: italic;
+  --neon-font-weight-placeholder: var(--neon-font-weight-normal);
+  --neon-font-weight-input: var(--neon-font-weight-normal);
+  --neon-line-height-input: var(--neon-line-height-ratio-large);
   --neon-opacity-input-background-active: 0.03125;
+
+  --neon-font-size-input-s: var(--neon-font-size-s);
+  --neon-font-size-input-m: var(--neon-font-size-m);
+  --neon-font-size-input-l: var(--neon-font-size-m);
+
+  /* input indicator */
+  --neon-font-size-input-indicator-s: var(--neon-font-size-s);
+  --neon-font-size-input-indicator-m: var(--neon-font-size-m);
+  --neon-font-size-input-indicator-l: var(--neon-font-size-m);
+  --neon-font-weight-input-indicator: var(--neon-font-weight-normal);
 
   /* skeleton loader */
   --neon-border-radius-skeleton-loader: 0rem;
@@ -655,7 +670,7 @@
 
     /* input indicators */
     --neon-background-color-input-indicator: var(--neon-background-color-input);
-    --neon-color-input-indicator: var(--neon-color-neutral);
+    --neon-color-input-indicator: var(--neon-color-text-tertiary);
 
     /* stepper */
     --neon-color-stepper-indicator: var(--neon-color-inverse);
@@ -969,7 +984,7 @@
 
     /* input indicators */
     --neon-background-color-input-indicator: var(--neon-background-color-input);
-    --neon-color-input-indicator: var(--neon-color-neutral);
+    --neon-color-input-indicator: var(--neon-color-text-tertiary);
 
     /* stepper */
     --neon-color-stepper-indicator: var(--neon-color-high-contrast-l5);


### PR DESCRIPTION
## Describe your changes
- Add support for `internal` indicator style
- Add `indicatorStyle`, `disabled`, `color` properties to `NeonFieldGroup`
- Expand CSS variable support on `NeonInput` to support specific Access use case (Offer amount)

BREAKING CHANGE: The field group indicator style defaults to `internal`, for pre-existing usage please use `<neon-field-group indicator-style="external">`.
