### PR TITLE
fix: card list style fixes

### DIFF
--- a/src/app/views/layout/card-list/CardList.scss
+++ b/src/app/views/layout/card-list/CardList.scss
@@ -11,7 +11,8 @@
 }
 
 .grid-card-contents {
-  width: 288rem;
+  width: 100%;
+  min-width: 288rem;
   height: 350rem;
   color: var(--neon-color-inverse);
   background-color: var(--neon-color-info);

--- a/src/components/layout/filter-bar/NeonFilterBar.ts
+++ b/src/components/layout/filter-bar/NeonFilterBar.ts
@@ -8,4 +8,7 @@ import NeonSwiper from '@/components/layout/swiper/NeonSwiper.vue';
 export default defineComponent({
   name: 'NeonFilterBar',
   components: { NeonInline, NeonSwiper },
+  setup(_props, { slots }) {
+    return { slots };
+  },
 });

--- a/src/components/layout/filter-bar/NeonFilterBar.vue
+++ b/src/components/layout/filter-bar/NeonFilterBar.vue
@@ -1,12 +1,12 @@
 <template>
   <neon-inline class="neon-filter-bar" gap="m">
-    <neon-swiper class="neon-filter-bar__swiper">
+    <neon-swiper v-if="slots.filters" class="neon-filter-bar__swiper">
       <neon-inline class="neon-filter-bar__filters">
         <!-- @slot container for filters, e.g. search-filter & filter components -->
         <slot name="filters"></slot>
       </neon-inline>
     </neon-swiper>
-    <div class="neon-filter-bar__sort">
+    <div v-if="slots.sort" class="neon-filter-bar__sort">
       <!-- @slot sort component, e.g. select component -->
       <slot name="sort"></slot>
     </div>

--- a/src/sass/components/_badge.scss
+++ b/src/sass/components/_badge.scss
@@ -124,7 +124,7 @@
           min-width: var(--neon-size-#{$badge-size}-badge);
           height: var(--neon-size-#{$badge-size}-badge);
           min-height: var(--neon-size-#{$badge-size}-badge);
-          object-fit: cover;
+          object-fit: var(--neon-object-fit-badge-image);
         }
 
         .neon-icon {

--- a/src/sass/components/_card-list.scss
+++ b/src/sass/components/_card-list.scss
@@ -91,26 +91,22 @@
     }
 
     &.neon-card-list--grid {
-      .neon-card-list__link {
-        width: fit-content;
-        min-width: fit-content;
-        max-width: fit-content;
-        display: inline-flex;
-        flex: 0 1 auto;
-      }
-
       .neon-card-list__cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(var(--neon-min-width-card-list-grid-card), 1fr));
         gap: var(--neon-space-32);
         margin-top: var(--neon-space-32);
         border-top: none;
-        flex-direction: row;
-        flex-wrap: wrap;
+      }
+
+      .neon-card-list__link {
+        width: 100%;
+        display: inline-flex;
+        align-items: flex-start;
       }
 
       .neon-card-list__card {
-        width: fit-content;
-        max-width: fit-content;
-        flex: 0 1 auto;
+        width: 100%;
         padding: 0 0 var(--neon-space-24) 0;
       }
     }

--- a/src/sass/variables-global.scss
+++ b/src/sass/variables-global.scss
@@ -1250,6 +1250,11 @@
    */
   --neon-border-radius-badge: var(--neon-border-radius);
   /**
+   * @component NeonBadge,NeonAvatar
+   * Badge image object fit property
+   */
+  --neon-object-fit-badge-image: cover;
+  /**
    * @component NeonBadge
    * Background gradient angle for a multicolored badge
    */
@@ -1424,4 +1429,12 @@
    * Font size of the header component subtitle
    */
   --neon-font-size-header-subtitle: var(--neon-font-size-m);
+
+
+  /* Card list component */
+  /**
+   * @component NeonCardList
+   * Set the min width of the card list grid card
+   */
+  --neon-min-width-card-list-grid-card: 288rem;
 }


### PR DESCRIPTION
## Describe your changes
- make filter bar full width when sort or filters not provided (remove gap)
- add CSS var for `--neon-object-fit-badge-image` to allow application to override the default of `cover`
- add CSS var for default grid style card width `--neon-min-width-card-list-grid-card` of 288rem
- adjust card grid layout to use CSS grid with flexible cards that expand to fill the space when necessary
